### PR TITLE
Harden validator scoring against miner gaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,12 @@ MINER_REQUEST_TIMEOUT_SECONDS=150
 VALIDATOR_EVAL_TOP_K=1
 # Maximum scored miner interval duration unless a ground-truth interval is longer.
 TASK_MAX_PREDICTION_DURATION_SECONDS=60
+# Apply a gentle post-quality latency multiplier.
+ENABLE_LATENCY_MULTIPLIER=0
+# Latency before the optional multiplier begins decaying.
+LATENCY_GRACE_SECONDS=30
+# Lowest optional multiplier near the miner request timeout.
+LATENCY_MIN_MULTIPLIER=0.85
 # EMA alpha used for instant miner quality scores.
 SCORE_EMA_ALPHA=0.1
 # Optional post-quality reliability multiplier weight.

--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,8 @@ MINER_SUBMISSION_CACHE_TTL_SECONDS=300
 MINER_SUBMISSION_REFRESH_INTERVAL_SECONDS=60
 # Per-runtime timeout in seconds for responsive miner /health checks.
 MINER_SUBMISSION_HEALTH_TIMEOUT_SECONDS=10
+# Optional JSON path for validator miner behavior telemetry snapshots.
+VALIDATOR_TELEMETRY_PATH=
 # Percent of miner emissions to burn by assigning weight to UID 0.
 MINER_EMISSION_BURN_PERCENT=0
 

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ TASK_CLIP_AUDIO_BITRATE=96k
 ENABLE_ADVERSARIAL_TASK_TRANSFORMS=1
 # Enable randomized encoding profile variants for hardened task clips.
 ENABLE_TASK_ENCODING_PROFILE_VARIANTS=1
+# Fraction of hardened tasks converted into internal canary tasks. Disabled by default.
+CANARY_TASK_RATE=0
+# Optional pipe-separated absent-query prompts for canary tasks.
+ABSENT_CANARY_QUERIES=
 
 # Validator Task Storage
 # Hippius S3-compatible endpoint for validator task uploads.

--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,10 @@ TASK_CLIP_MAX_HEIGHT=720
 TASK_CLIP_VIDEO_BITRATE=1500k
 # Generated task clip audio bitrate.
 TASK_CLIP_AUDIO_BITRATE=96k
+# Enable randomized hardened task context/encoding transforms.
+ENABLE_ADVERSARIAL_TASK_TRANSFORMS=1
+# Enable randomized encoding profile variants for hardened task clips.
+ENABLE_TASK_ENCODING_PROFILE_VARIANTS=1
 
 # Validator Task Storage
 # Hippius S3-compatible endpoint for validator task uploads.

--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,14 @@ ENABLE_TASK_ENCODING_PROFILE_VARIANTS=1
 CANARY_TASK_RATE=0
 # Optional pipe-separated absent-query prompts for canary tasks.
 ABSENT_CANARY_QUERIES=
+# Maximum active hardened artifacts per source video. 0 disables the limit.
+MAX_ACTIVE_TASKS_PER_SOURCE_VIDEO=0
+# Maximum active hardened artifacts per source caption. 0 disables the limit.
+MAX_ACTIVE_TASKS_PER_SOURCE_CAPTION=0
+# Maximum active hardened artifacts per query variant. 0 disables the limit.
+MAX_ACTIVE_TASKS_PER_QUERY_VARIANT=0
+# Maximum active hardened artifacts per encoding transform. 0 disables the limit.
+MAX_ACTIVE_TASKS_PER_TRANSFORM=0
 
 # Validator Task Storage
 # Hippius S3-compatible endpoint for validator task uploads.

--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,14 @@ MINER_REQUEST_TIMEOUT_SECONDS=150
 VALIDATOR_EVAL_TOP_K=1
 # Maximum scored miner interval duration unless a ground-truth interval is longer.
 TASK_MAX_PREDICTION_DURATION_SECONDS=60
+# EMA alpha used for instant miner quality scores.
+SCORE_EMA_ALPHA=0.1
+# Optional post-quality reliability multiplier weight.
+SCORE_RELIABILITY_WEIGHT=0
+# Optional post-quality consistency multiplier weight.
+SCORE_CONSISTENCY_WEIGHT=0
+# Optional post-quality suspicion multiplier weight.
+SCORE_SUSPICION_WEIGHT=0
 # Cache TTL in seconds for loaded miner metadata submissions.
 MINER_SUBMISSION_CACHE_TTL_SECONDS=300
 # Interval in seconds between validator submission metadata refreshes.

--- a/chronoseek/scoring.py
+++ b/chronoseek/scoring.py
@@ -30,6 +30,17 @@ DEFAULT_INTERVAL_SCORING = IntervalScoringConfig()
 PURE_IOU_SCORING = IntervalScoringConfig(enabled=False)
 
 
+@dataclass(frozen=True)
+class LatencyScoringConfig:
+    enabled: bool = False
+    grace_seconds: float = 30.0
+    timeout_seconds: float = 150.0
+    min_multiplier: float = 0.85
+
+
+DEFAULT_LATENCY_SCORING = LatencyScoringConfig()
+
+
 def calculate_iou(
     pred_start: float, pred_end: float, gt_start: float, gt_end: float
 ) -> float:
@@ -180,6 +191,34 @@ def best_interval_quality(
     return max_score
 
 
+def calculate_latency_multiplier(
+    latency: float,
+    *,
+    config: LatencyScoringConfig = DEFAULT_LATENCY_SCORING,
+) -> float:
+    if not config.enabled:
+        return 1.0
+
+    try:
+        latency_value = float(latency)
+    except (TypeError, ValueError):
+        latency_value = float("inf")
+
+    min_multiplier = max(0.0, min(1.0, float(config.min_multiplier)))
+    if not math.isfinite(latency_value) or latency_value < 0:
+        return min_multiplier
+
+    grace_seconds = max(0.0, float(config.grace_seconds))
+    timeout_seconds = max(grace_seconds, float(config.timeout_seconds))
+    if latency_value <= grace_seconds:
+        return 1.0
+    if timeout_seconds <= grace_seconds:
+        return min_multiplier
+
+    progress = min(1.0, (latency_value - grace_seconds) / (timeout_seconds - grace_seconds))
+    return max(min_multiplier, 1.0 - (progress * (1.0 - min_multiplier)))
+
+
 def _ground_truth_list(
     ground_truth: GroundTruthInterval | GroundTruthIntervals,
 ) -> list[GroundTruthInterval]:
@@ -260,13 +299,18 @@ def score_response(
     score_top_k: int | None = None,
     interval_scoring_config: IntervalScoringConfig = DEFAULT_INTERVAL_SCORING,
     expects_empty_response: bool = False,
+    latency_scoring_config: LatencyScoringConfig = DEFAULT_LATENCY_SCORING,
 ) -> float:
     """
     Score a miner's response using the best interval quality across predictions and ground truths.
     This returns a continuous value in [0, 1].
     """
     if expects_empty_response:
-        return 1.0 if not predictions else 0.0
+        base_score = 1.0 if not predictions else 0.0
+        return base_score * calculate_latency_multiplier(
+            latency,
+            config=latency_scoring_config,
+        )
 
     if not predictions:
         return 0.0
@@ -282,10 +326,14 @@ def score_response(
     if not filtered_predictions:
         return 0.0
 
-    return best_interval_quality(
+    quality_score = best_interval_quality(
         filtered_predictions,
         ground_truths,
         config=interval_scoring_config,
+    )
+    return quality_score * calculate_latency_multiplier(
+        latency,
+        config=latency_scoring_config,
     )
 
 

--- a/chronoseek/scoring.py
+++ b/chronoseek/scoring.py
@@ -259,11 +259,15 @@ def score_response(
     max_prediction_duration_seconds: float | None = None,
     score_top_k: int | None = None,
     interval_scoring_config: IntervalScoringConfig = DEFAULT_INTERVAL_SCORING,
+    expects_empty_response: bool = False,
 ) -> float:
     """
     Score a miner's response using the best interval quality across predictions and ground truths.
     This returns a continuous value in [0, 1].
     """
+    if expects_empty_response:
+        return 1.0 if not predictions else 0.0
+
     if not predictions:
         return 0.0
 

--- a/chronoseek/scoring.py
+++ b/chronoseek/scoring.py
@@ -1,10 +1,33 @@
 import math
+from dataclasses import dataclass
 from typing import Iterable, List, Tuple
 from chronoseek.protocol_models import VideoSearchResult
 
 GroundTruthInterval = Tuple[float, float]
 GroundTruthIntervals = Iterable[GroundTruthInterval]
 STRICT_IOU_THRESHOLD = 0.5
+
+
+@dataclass(frozen=True)
+class IntervalScoringConfig:
+    """
+    Controls the shape-aware interval quality score.
+
+    IoU remains the primary signal. When penalties are enabled, the best IoU is
+    multiplied by a shape factor made from center, boundary, and duration
+    alignment. This keeps zero-overlap predictions at zero and prevents broad
+    intervals from being rescued by auxiliary signals.
+    """
+
+    enabled: bool = True
+    iou_weight: float = 0.75
+    center_weight: float = 0.10
+    boundary_weight: float = 0.10
+    duration_weight: float = 0.05
+
+
+DEFAULT_INTERVAL_SCORING = IntervalScoringConfig()
+PURE_IOU_SCORING = IntervalScoringConfig(enabled=False)
 
 
 def calculate_iou(
@@ -52,6 +75,109 @@ def best_iou(
                 max_iou = iou
 
     return max_iou
+
+
+def _positive_duration(start: float, end: float) -> float:
+    return max(0.0, float(end) - float(start))
+
+
+def _safe_alignment(error: float, scale: float) -> float:
+    if scale <= 0:
+        return 0.0
+    return max(0.0, min(1.0, 1.0 - (abs(float(error)) / float(scale))))
+
+
+def _duration_alignment(pred_len: float, gt_len: float) -> float:
+    longer = max(float(pred_len), float(gt_len))
+    if longer <= 0:
+        return 0.0
+    return max(0.0, min(1.0, min(float(pred_len), float(gt_len)) / longer))
+
+
+def _normalized_weights(
+    config: IntervalScoringConfig,
+) -> tuple[float, float, float, float]:
+    weights = (
+        max(0.0, float(config.iou_weight)),
+        max(0.0, float(config.center_weight)),
+        max(0.0, float(config.boundary_weight)),
+        max(0.0, float(config.duration_weight)),
+    )
+    total = sum(weights)
+    if total <= 0:
+        return (1.0, 0.0, 0.0, 0.0)
+    return tuple(weight / total for weight in weights)
+
+
+def interval_quality_score(
+    prediction: VideoSearchResult,
+    ground_truth: GroundTruthInterval,
+    *,
+    config: IntervalScoringConfig = DEFAULT_INTERVAL_SCORING,
+) -> float:
+    """
+    Score one prediction/ground-truth interval pair.
+
+    The returned value is always in [0, 1]. With the default config it is IoU
+    dampened by interval-shape alignment; with `enabled=False` it is pure IoU.
+    """
+    gt_start, gt_end = ground_truth
+    iou = calculate_iou(prediction.start, prediction.end, gt_start, gt_end)
+    if not config.enabled or iou <= 0.0:
+        return iou
+
+    pred_len = _positive_duration(prediction.start, prediction.end)
+    gt_len = _positive_duration(gt_start, gt_end)
+    if pred_len <= 0.0 or gt_len <= 0.0:
+        return 0.0
+
+    pred_center = (float(prediction.start) + float(prediction.end)) / 2.0
+    gt_center = (float(gt_start) + float(gt_end)) / 2.0
+    center_scale = max(pred_len, gt_len)
+    center_alignment = _safe_alignment(pred_center - gt_center, center_scale)
+
+    boundary_scale = gt_len
+    start_alignment = _safe_alignment(
+        float(prediction.start) - float(gt_start),
+        boundary_scale,
+    )
+    end_alignment = _safe_alignment(
+        float(prediction.end) - float(gt_end),
+        boundary_scale,
+    )
+    boundary_alignment = (start_alignment + end_alignment) / 2.0
+
+    duration_alignment = _duration_alignment(pred_len, gt_len)
+    iou_weight, center_weight, boundary_weight, duration_weight = _normalized_weights(
+        config
+    )
+    shape_multiplier = (
+        iou_weight
+        + center_weight * center_alignment
+        + boundary_weight * boundary_alignment
+        + duration_weight * duration_alignment
+    )
+    return max(0.0, min(1.0, iou * shape_multiplier))
+
+
+def best_interval_quality(
+    predictions: List[VideoSearchResult],
+    ground_truths: GroundTruthIntervals,
+    *,
+    config: IntervalScoringConfig = DEFAULT_INTERVAL_SCORING,
+) -> float:
+    max_score = 0.0
+    normalized_ground_truths = list(ground_truths)
+    if not predictions or not normalized_ground_truths:
+        return 0.0
+
+    for pred in predictions:
+        for ground_truth in normalized_ground_truths:
+            score = interval_quality_score(pred, ground_truth, config=config)
+            if score > max_score:
+                max_score = score
+
+    return max_score
 
 
 def _ground_truth_list(
@@ -127,14 +253,15 @@ def valid_predictions(
 def score_response(
     predictions: List[VideoSearchResult],
     ground_truth: GroundTruthInterval | GroundTruthIntervals,
-    latency: float,  # Kept for API compatibility; current scoring is IoU-only.
+    latency: float,  # Kept for API compatibility; latency is handled by validators.
     *,
     clip_duration: float | None = None,
     max_prediction_duration_seconds: float | None = None,
     score_top_k: int | None = None,
+    interval_scoring_config: IntervalScoringConfig = DEFAULT_INTERVAL_SCORING,
 ) -> float:
     """
-    Score a miner's response using the best IoU across predictions and ground truths.
+    Score a miner's response using the best interval quality across predictions and ground truths.
     This returns a continuous value in [0, 1].
     """
     if not predictions:
@@ -151,7 +278,11 @@ def score_response(
     if not filtered_predictions:
         return 0.0
 
-    return best_iou(filtered_predictions, ground_truths)
+    return best_interval_quality(
+        filtered_predictions,
+        ground_truths,
+        config=interval_scoring_config,
+    )
 
 
 def passes_strict_iou(score: float, threshold: float = STRICT_IOU_THRESHOLD) -> bool:

--- a/chronoseek/validator/aggregation.py
+++ b/chronoseek/validator/aggregation.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from chronoseek.validator.telemetry import MinerTelemetrySummary
+
+
+@dataclass(frozen=True)
+class ScoreAggregationConfig:
+    alpha: float = 0.1
+    reliability_weight: float = 0.0
+    consistency_weight: float = 0.0
+    suspicion_weight: float = 0.0
+
+
+@dataclass(frozen=True)
+class MinerScoreComponents:
+    quality_score: float
+    reliability_score: float
+    consistency_score: float
+    suspicion_score: float
+    final_score: float
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _weighted_multiplier(*, component_score: float, weight: float) -> float:
+    weight = _clamp01(weight)
+    return 1.0 - (weight * (1.0 - _clamp01(component_score)))
+
+
+def update_miner_score(
+    *,
+    previous_score: float,
+    instant_score: float,
+    telemetry_summary: MinerTelemetrySummary | None,
+    config: ScoreAggregationConfig = ScoreAggregationConfig(),
+) -> MinerScoreComponents:
+    alpha = _clamp01(config.alpha)
+    quality_score = alpha * float(instant_score) + (1.0 - alpha) * float(previous_score)
+
+    if telemetry_summary is None or telemetry_summary.attempts == 0:
+        reliability_score = 1.0
+        consistency_score = 1.0
+        suspicion_score = 1.0
+    else:
+        reliability_score = 1.0 - telemetry_summary.error_rate
+        consistency_score = 1.0 - min(1.0, telemetry_summary.score_stddev)
+        flags = telemetry_summary.suspicion_flags()
+        suspicion_score = max(0.0, 1.0 - (0.25 * len(flags)))
+
+    multiplier = (
+        _weighted_multiplier(
+            component_score=reliability_score,
+            weight=config.reliability_weight,
+        )
+        * _weighted_multiplier(
+            component_score=consistency_score,
+            weight=config.consistency_weight,
+        )
+        * _weighted_multiplier(
+            component_score=suspicion_score,
+            weight=config.suspicion_weight,
+        )
+    )
+    final_score = max(0.0, quality_score * multiplier)
+    return MinerScoreComponents(
+        quality_score=quality_score,
+        reliability_score=_clamp01(reliability_score),
+        consistency_score=_clamp01(consistency_score),
+        suspicion_score=_clamp01(suspicion_score),
+        final_score=final_score,
+    )

--- a/chronoseek/validator/artifact_manifest.py
+++ b/chronoseek/validator/artifact_manifest.py
@@ -15,6 +15,12 @@ class ArtifactManifestEntry:
     encoding_profile: str
     created_at: float
     expires_at: float
+    source_video_id: str = ""
+    source_caption_id: str = ""
+    query_variant_id: str = ""
+    crop_bucket: str = ""
+    transform_id: str = ""
+    task_family: str = "hardened-activitynet"
 
 
 class TaskArtifactManifest:
@@ -56,6 +62,57 @@ class TaskArtifactManifest:
             entry.source_task_hash
             for entry in self.entries.values()
             if entry.expires_at > current_time
+        }
+
+    def active_entries(self, now: float | None = None) -> list[ArtifactManifestEntry]:
+        current_time = time.time() if now is None else float(now)
+        return [
+            entry
+            for entry in self.entries.values()
+            if entry.expires_at > current_time
+        ]
+
+    def exposure_counts(
+        self,
+        *,
+        field_name: str,
+        now: float | None = None,
+    ) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in self.active_entries(now=now):
+            value = str(getattr(entry, field_name, "") or "")
+            if not value:
+                continue
+            counts[value] = counts.get(value, 0) + 1
+        return counts
+
+    def exposure_summary(self, now: float | None = None) -> dict[str, int]:
+        active_entries = self.active_entries(now=now)
+        return {
+            "active_artifacts": len(active_entries),
+            "source_videos": len(
+                {entry.source_video_id for entry in active_entries if entry.source_video_id}
+            ),
+            "source_captions": len(
+                {
+                    entry.source_caption_id
+                    for entry in active_entries
+                    if entry.source_caption_id
+                }
+            ),
+            "query_variants": len(
+                {
+                    entry.query_variant_id
+                    for entry in active_entries
+                    if entry.query_variant_id
+                }
+            ),
+            "transforms": len(
+                {entry.transform_id for entry in active_entries if entry.transform_id}
+            ),
+            "task_families": len(
+                {entry.task_family for entry in active_entries if entry.task_family}
+            ),
         }
 
     def cleanup_expired(

--- a/chronoseek/validator/clipper.py
+++ b/chronoseek/validator/clipper.py
@@ -73,6 +73,7 @@ class FfmpegClipper:
         ground_truths: GroundTruthIntervals,
         rng,
         source_duration: float | None = None,
+        hard_negative_intervals: GroundTruthIntervals | None = None,
     ) -> CropPlan:
         if not ground_truths:
             raise RuntimeError("Cannot crop a task without ground-truth intervals.")
@@ -82,13 +83,32 @@ class FfmpegClipper:
         anchor_end = max(anchor_start + 0.1, float(anchor_end))
         anchor_duration = anchor_end - anchor_start
 
+        hard_negative_intervals = list(hard_negative_intervals or [])
+        combined_start = anchor_start
+        combined_end = anchor_end
+        usable_negative_intervals = [
+            (max(0.0, float(start)), max(float(start) + 0.1, float(end)))
+            for start, end in hard_negative_intervals
+        ]
+        if usable_negative_intervals:
+            negative_start, negative_end = rng.choice(usable_negative_intervals)
+            candidate_start = min(anchor_start, negative_start)
+            candidate_end = max(anchor_end, negative_end)
+            if candidate_end - candidate_start <= self.max_clip_duration_seconds:
+                combined_start = candidate_start
+                combined_end = candidate_end
+
+        combined_duration = combined_end - combined_start
         desired_duration = max(
             self.min_clip_duration_seconds,
-            min(self.max_clip_duration_seconds, anchor_duration + rng.uniform(12.0, 45.0)),
+            min(
+                self.max_clip_duration_seconds,
+                combined_duration + rng.uniform(12.0, 45.0),
+            ),
         )
-        leading_context_max = max(0.0, desired_duration - anchor_duration)
+        leading_context_max = max(0.0, desired_duration - combined_duration)
         leading_context = rng.uniform(0.0, leading_context_max)
-        crop_start = max(0.0, anchor_start - leading_context)
+        crop_start = max(0.0, combined_start - leading_context)
         crop_end = crop_start + desired_duration
 
         if source_duration is not None and crop_end > source_duration:
@@ -176,6 +196,7 @@ class FfmpegClipper:
         source_video_id: str,
         ground_truths: GroundTruthIntervals,
         rng,
+        hard_negative_intervals: GroundTruthIntervals | None = None,
     ) -> ClipResult:
         downloaded_video = VideoDownloader.download_video(
             source_video_url,
@@ -190,6 +211,7 @@ class FfmpegClipper:
                 ground_truths=ground_truths,
                 rng=rng,
                 source_duration=source_duration,
+                hard_negative_intervals=hard_negative_intervals,
             )
             source_dir = self.cache_dir / source_video_id.replace("/", "_")
             source_dir.mkdir(parents=True, exist_ok=True)

--- a/chronoseek/validator/forward.py
+++ b/chronoseek/validator/forward.py
@@ -14,7 +14,7 @@ from chronoseek.protocol_models import (
     VideoSearchRequest,
     VideoSearchResponse,
 )
-from chronoseek.scoring import score_response
+from chronoseek.scoring import LatencyScoringConfig, score_response
 from chronoseek.epistula import generate_header
 from chronoseek.chutes.runtime import ChutesRuntimeEndpoint
 from chronoseek.validator.task_models import normalize_generated_task
@@ -150,6 +150,7 @@ async def query_uid(
     canary_kind: str | None = None,
     transform_id: str | None = None,
     hard_negative_count: int = 0,
+    latency_scoring_config: LatencyScoringConfig | None = None,
     telemetry_recorder=None,
 ) -> Tuple[int, float]:
     async with semaphore:
@@ -172,11 +173,19 @@ async def query_uid(
 
         if not resp.results:
             if expects_empty_response and result.failure is None:
+                score = score_response(
+                    [],
+                    [],
+                    latency,
+                    expects_empty_response=True,
+                    latency_scoring_config=latency_scoring_config
+                    or LatencyScoringConfig(),
+                )
                 if telemetry_recorder is not None:
                     telemetry_recorder(
                         MinerTelemetryEvent(
                             uid=int(uid),
-                            score=1.0,
+                            score=score,
                             latency=latency,
                             task_family=task_family,
                             canary_kind=canary_kind,
@@ -187,9 +196,9 @@ async def query_uid(
                 bt.logging.success(
                     f"[UID {uid}] Empty canary response accepted | "
                     f"Request: {request_model.request_id} | "
-                    f"Latency: {latency:.2f}s | Score: 1.0000"
+                    f"Latency: {latency:.2f}s | Score: {score:.4f}"
                 )
-                return int(uid), 1.0
+                return int(uid), score
 
             failure_suffix = ""
             if result.failure is not None:
@@ -239,6 +248,7 @@ async def query_uid(
             max_prediction_duration_seconds=max_prediction_duration_seconds,
             score_top_k=1,
             expects_empty_response=expects_empty_response,
+            latency_scoring_config=latency_scoring_config or LatencyScoringConfig(),
         )
         result = resp.results[0]
         res_str = f"[{result.start:.1f}s - {result.end:.1f}s]"
@@ -272,6 +282,7 @@ async def run_step(
     provider_headers: dict[str, str] | None = None,
     validator_eval_top_k: int = 1,
     max_prediction_duration_seconds: float = 60.0,
+    latency_scoring_config: LatencyScoringConfig | None = None,
     telemetry_recorder=None,
 ) -> List[Tuple[int, float]]:
     """
@@ -375,6 +386,7 @@ async def run_step(
                 canary_kind=normalized_task.canary_kind,
                 transform_id=normalized_task.transform_id,
                 hard_negative_count=normalized_task.hard_negative_count,
+                latency_scoring_config=latency_scoring_config,
                 telemetry_recorder=telemetry_recorder,
             )
         )

--- a/chronoseek/validator/forward.py
+++ b/chronoseek/validator/forward.py
@@ -18,6 +18,7 @@ from chronoseek.scoring import score_response
 from chronoseek.epistula import generate_header
 from chronoseek.chutes.runtime import ChutesRuntimeEndpoint
 from chronoseek.validator.task_models import normalize_generated_task
+from chronoseek.validator.telemetry import MinerTelemetryEvent
 
 MAX_CONCURRENT_MINER_REQUESTS = 8
 
@@ -145,6 +146,11 @@ async def query_uid(
     max_prediction_duration_seconds: float | None = None,
     extra_headers: dict[str, str] | None = None,
     expects_empty_response: bool = False,
+    task_family: str = "legacy-activitynet",
+    canary_kind: str | None = None,
+    transform_id: str | None = None,
+    hard_negative_count: int = 0,
+    telemetry_recorder=None,
 ) -> Tuple[int, float]:
     async with semaphore:
         uid = miner_endpoint.uid
@@ -166,6 +172,18 @@ async def query_uid(
 
         if not resp.results:
             if expects_empty_response and result.failure is None:
+                if telemetry_recorder is not None:
+                    telemetry_recorder(
+                        MinerTelemetryEvent(
+                            uid=int(uid),
+                            score=1.0,
+                            latency=latency,
+                            task_family=task_family,
+                            canary_kind=canary_kind,
+                            transform_id=transform_id,
+                            hard_negative_count=hard_negative_count,
+                        )
+                    )
                 bt.logging.success(
                     f"[UID {uid}] Empty canary response accepted | "
                     f"Request: {request_model.request_id} | "
@@ -186,6 +204,31 @@ async def query_uid(
             bt.logging.warning(
                 f"[UID {uid}] No results | Request: {request_model.request_id} | Latency: {latency:.2f}s | Score: 0.0000{failure_suffix}"
             )
+            if telemetry_recorder is not None:
+                telemetry_recorder(
+                    MinerTelemetryEvent(
+                        uid=int(uid),
+                        score=0.0,
+                        latency=latency,
+                        task_family=task_family,
+                        canary_kind=canary_kind,
+                        transform_id=transform_id,
+                        hard_negative_count=hard_negative_count,
+                        failure_kind=(
+                            result.failure.kind if result.failure is not None else None
+                        ),
+                        protocol_code=(
+                            result.failure.protocol_code
+                            if result.failure is not None
+                            else None
+                        ),
+                        status_code=(
+                            result.failure.status_code
+                            if result.failure is not None
+                            else None
+                        ),
+                    )
+                )
             return int(uid), 0.0
 
         score = score_response(
@@ -199,6 +242,20 @@ async def query_uid(
         )
         result = resp.results[0]
         res_str = f"[{result.start:.1f}s - {result.end:.1f}s]"
+        if telemetry_recorder is not None:
+            telemetry_recorder(
+                MinerTelemetryEvent(
+                    uid=int(uid),
+                    score=score,
+                    latency=latency,
+                    task_family=task_family,
+                    canary_kind=canary_kind,
+                    transform_id=transform_id,
+                    hard_negative_count=hard_negative_count,
+                    top_start=float(result.start),
+                    top_end=float(result.end),
+                )
+            )
         bt.logging.success(
             f"[UID {uid}] Request: {request_model.request_id} | Score: {score:.4f} | Latency: {latency:.2f}s | Result: {res_str}"
         )
@@ -215,6 +272,7 @@ async def run_step(
     provider_headers: dict[str, str] | None = None,
     validator_eval_top_k: int = 1,
     max_prediction_duration_seconds: float = 60.0,
+    telemetry_recorder=None,
 ) -> List[Tuple[int, float]]:
     """
     Run a single validation step:
@@ -264,6 +322,7 @@ async def run_step(
     ground_truths = normalized_task.ground_truths
     clip_duration = normalized_task.clip_duration
     artifact_host = urlparse(video_url).netloc or "unknown"
+    task_family = normalized_task.task_family or "legacy-activitynet"
 
     bt.logging.info("-" * 40)
     bt.logging.info(f"Request ID:  {request_id}")
@@ -312,6 +371,11 @@ async def run_step(
                 max_prediction_duration_seconds=max_prediction_duration_seconds,
                 extra_headers=provider_headers,
                 expects_empty_response=normalized_task.expects_empty_response,
+                task_family=task_family,
+                canary_kind=normalized_task.canary_kind,
+                transform_id=normalized_task.transform_id,
+                hard_negative_count=normalized_task.hard_negative_count,
+                telemetry_recorder=telemetry_recorder,
             )
         )
 

--- a/chronoseek/validator/forward.py
+++ b/chronoseek/validator/forward.py
@@ -144,6 +144,7 @@ async def query_uid(
     clip_duration: float | None = None,
     max_prediction_duration_seconds: float | None = None,
     extra_headers: dict[str, str] | None = None,
+    expects_empty_response: bool = False,
 ) -> Tuple[int, float]:
     async with semaphore:
         uid = miner_endpoint.uid
@@ -164,6 +165,14 @@ async def query_uid(
         latency = result.latency
 
         if not resp.results:
+            if expects_empty_response and result.failure is None:
+                bt.logging.success(
+                    f"[UID {uid}] Empty canary response accepted | "
+                    f"Request: {request_model.request_id} | "
+                    f"Latency: {latency:.2f}s | Score: 1.0000"
+                )
+                return int(uid), 1.0
+
             failure_suffix = ""
             if result.failure is not None:
                 parts = [result.failure.kind]
@@ -186,6 +195,7 @@ async def query_uid(
             clip_duration=clip_duration,
             max_prediction_duration_seconds=max_prediction_duration_seconds,
             score_top_k=1,
+            expects_empty_response=expects_empty_response,
         )
         result = resp.results[0]
         res_str = f"[{result.start:.1f}s - {result.end:.1f}s]"
@@ -260,6 +270,11 @@ async def run_step(
     bt.logging.info(f"Task ID:     {normalized_task.task_id or 'legacy-task'}")
     bt.logging.info(f"Artifact Host: {artifact_host}")
     bt.logging.info(f"Query Variant: {normalized_task.query_variant_id or 'legacy-query'}")
+    if normalized_task.canary_kind:
+        bt.logging.info(
+            f"Canary: {normalized_task.canary_kind} | "
+            f"expects_empty={normalized_task.expects_empty_response}"
+        )
     bt.logging.info(f"Clip Duration: {clip_duration if clip_duration is not None else 'unknown'}")
     bt.logging.info(f"Ground Truth Count: {len(ground_truths)}")
     bt.logging.info("-" * 40)
@@ -296,6 +311,7 @@ async def run_step(
                 clip_duration=clip_duration,
                 max_prediction_duration_seconds=max_prediction_duration_seconds,
                 extra_headers=provider_headers,
+                expects_empty_response=normalized_task.expects_empty_response,
             )
         )
 

--- a/chronoseek/validator/hardened_task_gen.py
+++ b/chronoseek/validator/hardened_task_gen.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -55,6 +55,12 @@ class HardenedTaskGeneratorConfig:
     delete_remote_artifacts: bool = False
     enable_adversarial_transforms: bool = True
     enable_encoding_profile_variants: bool = True
+    canary_task_rate: float = 0.0
+    absent_canary_queries: tuple[str, ...] = (
+        "a blue whale playing chess on a snow-covered tennis court",
+        "a person juggling five glowing green pineapples underwater",
+        "the exact phrase chronoseek absent canary appears on screen",
+    )
 
 
 class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
@@ -236,6 +242,49 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
             "hard_negative_count": int(hard_negative_count),
         }
 
+    def _maybe_apply_canary(self, *, task: ValidationTask, sample, rng) -> ValidationTask:
+        rate = max(0.0, min(1.0, float(self.config.canary_task_rate)))
+        if rate <= 0.0 or rng.random() >= rate:
+            return task
+
+        candidates = ["absent"]
+        if task.hard_negative_count > 0:
+            candidates.append("hard-negative")
+        if len(task.ground_truths) > 1:
+            candidates.append("repeated")
+
+        canary_kind = rng.choice(candidates)
+        metadata = {
+            **task.transform_metadata,
+            "canary_kind": canary_kind,
+            "canary_source": "validator",
+        }
+
+        if canary_kind == "absent":
+            absent_queries = tuple(
+                query.strip()
+                for query in self.config.absent_canary_queries
+                if query.strip()
+            )
+            query = rng.choice(absent_queries or ("an event that is not present",))
+            return replace(
+                task,
+                task_family="canary-absent",
+                query=query,
+                ground_truths=[],
+                canary_kind=canary_kind,
+                expects_empty_response=True,
+                transform_metadata=metadata,
+            )
+
+        return replace(
+            task,
+            task_family=f"canary-{canary_kind}",
+            canary_kind=canary_kind,
+            expects_empty_response=False,
+            transform_metadata=metadata,
+        )
+
     @staticmethod
     def _remove_local_file(path: str | None) -> None:
         if not path:
@@ -351,7 +400,7 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     f"transform={selected_profile.name} | "
                     f"hard_negatives={len(hard_negative_ids)}"
                 )
-                return ValidationTask(
+                task = ValidationTask(
                     task_id=task_id,
                     request_id=f"validation-{task_id}",
                     video_url=artifact_url,
@@ -375,6 +424,7 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     hard_negative_count=len(hard_negative_ids),
                     hard_negative_source_caption_ids=hard_negative_ids,
                 )
+                return self._maybe_apply_canary(task=task, sample=sample, rng=rng)
             except Exception as exc:
                 self._remove_local_file(clip_path)
                 self._remove_local_file(compressed_path)

--- a/chronoseek/validator/hardened_task_gen.py
+++ b/chronoseek/validator/hardened_task_gen.py
@@ -1,8 +1,9 @@
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 import bittensor as bt
 
@@ -14,7 +15,11 @@ from chronoseek.validator.base_task_gen import BaseTaskGenerator
 from chronoseek.validator.clipper import FfmpegClipper
 from chronoseek.validator.query_variants import QueryVariantSelector
 from chronoseek.validator.compression import CompressionResult
-from chronoseek.validator.task_models import ValidationTask
+from chronoseek.validator.task_models import (
+    EncodingProfile,
+    GroundTruthIntervals,
+    ValidationTask,
+)
 from chronoseek.validator.task_sampler import (
     ActivityNetTaskSampler,
     build_source_task_hash,
@@ -48,6 +53,8 @@ class HardenedTaskGeneratorConfig:
     cleanup_interval_seconds: float = 900.0
     max_generation_attempts: int = 5
     delete_remote_artifacts: bool = False
+    enable_adversarial_transforms: bool = True
+    enable_encoding_profile_variants: bool = True
 
 
 class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
@@ -113,6 +120,123 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
         return f"{prefix}/{task_id}.mp4"
 
     @staticmethod
+    def _scale_bitrate(value: str, factor: float) -> str:
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)([kKmM]?)", str(value).strip())
+        if not match:
+            return value
+        number = float(match.group(1))
+        suffix = match.group(2)
+        scaled = max(1, int(round(number * float(factor))))
+        return f"{scaled}{suffix}"
+
+    @staticmethod
+    def _profile_variants(base_profile: EncodingProfile) -> list[EncodingProfile]:
+        return [
+            EncodingProfile(
+                name=f"{base_profile.name}:base",
+                max_width=base_profile.max_width,
+                max_height=base_profile.max_height,
+                video_bitrate=base_profile.video_bitrate,
+                audio_bitrate=base_profile.audio_bitrate,
+            ),
+            EncodingProfile(
+                name=f"{base_profile.name}:compact",
+                max_width=min(base_profile.max_width, 960),
+                max_height=min(base_profile.max_height, 540),
+                video_bitrate=HardenedActivityNetTaskGenerator._scale_bitrate(
+                    base_profile.video_bitrate,
+                    0.80,
+                ),
+                audio_bitrate=base_profile.audio_bitrate,
+            ),
+            EncodingProfile(
+                name=f"{base_profile.name}:detail",
+                max_width=base_profile.max_width,
+                max_height=base_profile.max_height,
+                video_bitrate=HardenedActivityNetTaskGenerator._scale_bitrate(
+                    base_profile.video_bitrate,
+                    1.15,
+                ),
+                audio_bitrate=base_profile.audio_bitrate,
+            ),
+        ]
+
+    @staticmethod
+    def _encoding_profile(component: Any) -> EncodingProfile | None:
+        profile = getattr(component, "encoding_profile", None)
+        return profile if isinstance(profile, EncodingProfile) else None
+
+    def _select_encoding_profile(self, *, rng) -> EncodingProfile:
+        base_profile = self._encoding_profile(self.clipper) or EncodingProfile()
+        if (
+            not self.config.enable_adversarial_transforms
+            or not self.config.enable_encoding_profile_variants
+        ):
+            return base_profile
+        return rng.choice(self._profile_variants(base_profile))
+
+    @staticmethod
+    def _apply_encoding_profile(component: Any, profile: EncodingProfile) -> None:
+        if component is None:
+            return
+        if hasattr(component, "encoding_profile"):
+            try:
+                setattr(component, "encoding_profile", profile)
+            except Exception:
+                pass
+        for child_name in ("local_compressor", "preferred_compressor"):
+            child = getattr(component, child_name, None)
+            if child is not None:
+                HardenedActivityNetTaskGenerator._apply_encoding_profile(child, profile)
+
+    @staticmethod
+    def _flatten_intervals(groups: list[GroundTruthIntervals]) -> GroundTruthIntervals:
+        intervals: GroundTruthIntervals = []
+        for group in groups:
+            intervals.extend(group)
+        return intervals
+
+    @staticmethod
+    def _overlap_seconds(left: tuple[float, float], right: tuple[float, float]) -> float:
+        return max(0.0, min(float(left[1]), float(right[1])) - max(float(left[0]), float(right[0])))
+
+    @classmethod
+    def _hard_negative_ids_in_crop(cls, sample, crop_plan) -> tuple[str, ...]:
+        crop_interval = (float(crop_plan.source_start), float(crop_plan.source_end))
+        ids: list[str] = []
+        for negative in getattr(sample, "hard_negatives", ()):
+            if any(
+                cls._overlap_seconds((float(start), float(end)), crop_interval) > 0.0
+                for start, end in negative.ground_truths
+            ):
+                ids.append(negative.source_caption_id)
+        return tuple(sorted(set(ids)))
+
+    @staticmethod
+    def _transform_metadata(
+        *,
+        profile: EncodingProfile,
+        clip_result,
+        hard_negative_count: int,
+    ) -> dict[str, Any]:
+        crop_plan = clip_result.crop_plan
+        first_gt_start = min(start for start, _ in crop_plan.shifted_ground_truths)
+        last_gt_end = max(end for _, end in crop_plan.shifted_ground_truths)
+        return {
+            "encoding_profile": profile.name,
+            "max_width": profile.max_width,
+            "max_height": profile.max_height,
+            "video_bitrate": profile.video_bitrate,
+            "audio_bitrate": profile.audio_bitrate,
+            "leading_context_seconds": round(float(first_gt_start), 3),
+            "trailing_context_seconds": round(
+                max(0.0, float(crop_plan.clip_duration) - float(last_gt_end)),
+                3,
+            ),
+            "hard_negative_count": int(hard_negative_count),
+        }
+
+    @staticmethod
     def _remove_local_file(path: str | None) -> None:
         if not path:
             return
@@ -144,6 +268,9 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     source_caption_id=sample.source_caption_id,
                     rng=rng,
                 )
+                selected_profile = self._select_encoding_profile(rng=rng)
+                self._apply_encoding_profile(self.clipper, selected_profile)
+                self._apply_encoding_profile(self.compressor, selected_profile)
                 task_seed = stable_hash(
                     self.validator_hotkey,
                     block,
@@ -151,23 +278,35 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     sample.source_video_id,
                     sample.source_caption_id,
                     query_variant.variant_id,
+                    selected_profile.name,
                     now,
                 )
                 task_id = task_seed[:24]
+                hard_negative_intervals = self._flatten_intervals(
+                    [
+                        negative.ground_truths
+                        for negative in getattr(sample, "hard_negatives", ())
+                    ]
+                )
                 clip_result = self.clipper.create_clip(
                     source_video_url=sample.source_url,
                     task_id=task_id,
                     source_video_id=sample.source_video_id,
                     ground_truths=sample.ground_truths,
                     rng=rng,
+                    hard_negative_intervals=hard_negative_intervals,
                 )
                 clip_path = clip_result.path
+                hard_negative_ids = self._hard_negative_ids_in_crop(
+                    sample,
+                    clip_result.crop_plan,
+                )
                 source_task_hash = build_source_task_hash(
                     source_video_id=sample.source_video_id,
                     source_caption_id=sample.source_caption_id,
                     crop_bucket=clip_result.crop_bucket,
                     query_variant_id=query_variant.variant_id,
-                    encoding_profile=self.clipper.encoding_profile.name,
+                    encoding_profile=selected_profile.name,
                 )
                 if source_task_hash in active_source_hashes:
                     self._remove_local_file(clip_path)
@@ -208,7 +347,9 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     f"task_id={task_id} | request_id=validation-{task_id} | "
                     f"clip_duration={clip_result.crop_plan.clip_duration:.2f}s | "
                     f"query_variant={query_variant.variant_id} | "
-                    f"gt_count={len(clip_result.crop_plan.shifted_ground_truths)}"
+                    f"gt_count={len(clip_result.crop_plan.shifted_ground_truths)} | "
+                    f"transform={selected_profile.name} | "
+                    f"hard_negatives={len(hard_negative_ids)}"
                 )
                 return ValidationTask(
                     task_id=task_id,
@@ -225,6 +366,14 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     artifact_url=artifact_url,
                     artifact_key=object_key,
                     expires_at=expires_at,
+                    transform_id=selected_profile.name,
+                    transform_metadata=self._transform_metadata(
+                        profile=selected_profile,
+                        clip_result=clip_result,
+                        hard_negative_count=len(hard_negative_ids),
+                    ),
+                    hard_negative_count=len(hard_negative_ids),
+                    hard_negative_source_caption_ids=hard_negative_ids,
                 )
             except Exception as exc:
                 self._remove_local_file(clip_path)

--- a/chronoseek/validator/hardened_task_gen.py
+++ b/chronoseek/validator/hardened_task_gen.py
@@ -61,6 +61,10 @@ class HardenedTaskGeneratorConfig:
         "a person juggling five glowing green pineapples underwater",
         "the exact phrase chronoseek absent canary appears on screen",
     )
+    max_active_tasks_per_source_video: int = 0
+    max_active_tasks_per_source_caption: int = 0
+    max_active_tasks_per_query_variant: int = 0
+    max_active_tasks_per_transform: int = 0
 
 
 class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
@@ -243,6 +247,7 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
         }
 
     def _maybe_apply_canary(self, *, task: ValidationTask, sample, rng) -> ValidationTask:
+        del sample
         rate = max(0.0, min(1.0, float(self.config.canary_task_rate)))
         if rate <= 0.0 or rng.random() >= rate:
             return task
@@ -286,6 +291,56 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
         )
 
     @staticmethod
+    def _limit_exceeded(*, current_count: int, limit: int) -> bool:
+        return int(limit) > 0 and int(current_count) >= int(limit)
+
+    def _exposure_limit_exceeded(
+        self,
+        *,
+        now: float,
+        source_video_id: str,
+        source_caption_id: str,
+        query_variant_id: str,
+        transform_id: str,
+    ) -> bool:
+        checks = [
+            (
+                "source_video_id",
+                source_video_id,
+                self.config.max_active_tasks_per_source_video,
+            ),
+            (
+                "source_caption_id",
+                source_caption_id,
+                self.config.max_active_tasks_per_source_caption,
+            ),
+            (
+                "query_variant_id",
+                query_variant_id,
+                self.config.max_active_tasks_per_query_variant,
+            ),
+            (
+                "transform_id",
+                transform_id,
+                self.config.max_active_tasks_per_transform,
+            ),
+        ]
+        for field_name, value, limit in checks:
+            if not value or int(limit) <= 0:
+                continue
+            count = self.manifest.exposure_counts(field_name=field_name, now=now).get(
+                value,
+                0,
+            )
+            if self._limit_exceeded(current_count=count, limit=limit):
+                bt.logging.debug(
+                    "Skipping hardened task candidate due to exposure limit | "
+                    f"field={field_name} | value={value} | count={count} | limit={limit}"
+                )
+                return True
+        return False
+
+    @staticmethod
     def _remove_local_file(path: str | None) -> None:
         if not path:
             return
@@ -320,6 +375,14 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                 selected_profile = self._select_encoding_profile(rng=rng)
                 self._apply_encoding_profile(self.clipper, selected_profile)
                 self._apply_encoding_profile(self.compressor, selected_profile)
+                if self._exposure_limit_exceeded(
+                    now=now,
+                    source_video_id=sample.source_video_id,
+                    source_caption_id=sample.source_caption_id,
+                    query_variant_id=query_variant.variant_id,
+                    transform_id=selected_profile.name,
+                ):
+                    continue
                 task_seed = stable_hash(
                     self.validator_hotkey,
                     block,
@@ -389,8 +452,15 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                         encoding_profile=compression_result.profile_name,
                         created_at=now,
                         expires_at=expires_at,
+                        source_video_id=sample.source_video_id,
+                        source_caption_id=sample.source_caption_id,
+                        query_variant_id=query_variant.variant_id,
+                        crop_bucket=clip_result.crop_bucket,
+                        transform_id=selected_profile.name,
+                        task_family="hardened-activitynet",
                     )
                 )
+                exposure = self.manifest.exposure_summary(now=now)
                 bt.logging.info(
                     "Generated hardened validator task | "
                     f"task_id={task_id} | request_id=validation-{task_id} | "
@@ -398,7 +468,8 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     f"query_variant={query_variant.variant_id} | "
                     f"gt_count={len(clip_result.crop_plan.shifted_ground_truths)} | "
                     f"transform={selected_profile.name} | "
-                    f"hard_negatives={len(hard_negative_ids)}"
+                    f"hard_negatives={len(hard_negative_ids)} | "
+                    f"active_artifacts={exposure['active_artifacts']}"
                 )
                 task = ValidationTask(
                     task_id=task_id,
@@ -424,7 +495,11 @@ class HardenedActivityNetTaskGenerator(BaseTaskGenerator):
                     hard_negative_count=len(hard_negative_ids),
                     hard_negative_source_caption_ids=hard_negative_ids,
                 )
-                return self._maybe_apply_canary(task=task, sample=sample, rng=rng)
+                task = self._maybe_apply_canary(task=task, sample=sample, rng=rng)
+                manifest_entry = self.manifest.entries.get(task_id)
+                if manifest_entry is not None and manifest_entry.task_family != task.task_family:
+                    self.manifest.add(replace(manifest_entry, task_family=task.task_family))
+                return task
             except Exception as exc:
                 self._remove_local_file(clip_path)
                 self._remove_local_file(compressed_path)

--- a/chronoseek/validator/state.py
+++ b/chronoseek/validator/state.py
@@ -4,6 +4,8 @@ from threading import Lock
 import bittensor as bt
 import numpy as np
 
+from chronoseek.validator.telemetry import ValidatorTelemetryState
+
 
 @dataclass
 class ValidatorRuntimeState:
@@ -20,3 +22,4 @@ class ValidatorRuntimeState:
     responsive_initialized: bool = False
     responsive_last_refresh_at: float | None = None
     last_metagraph_sync_block: int | None = None
+    telemetry: ValidatorTelemetryState = field(default_factory=ValidatorTelemetryState)

--- a/chronoseek/validator/task_models.py
+++ b/chronoseek/validator/task_models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 GroundTruthInterval = tuple[float, float]
@@ -31,6 +31,12 @@ class EncodingProfile:
 
 
 @dataclass(frozen=True)
+class HardNegativeSignal:
+    source_caption_id: str
+    shifted_ground_truths: GroundTruthIntervals
+
+
+@dataclass(frozen=True)
 class ValidationTask:
     task_id: str
     request_id: str
@@ -46,6 +52,11 @@ class ValidationTask:
     artifact_url: str
     artifact_key: str
     expires_at: float
+    task_family: str = "hardened-activitynet"
+    transform_id: str = "base"
+    transform_metadata: dict[str, Any] = field(default_factory=dict)
+    hard_negative_count: int = 0
+    hard_negative_source_caption_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -58,6 +69,9 @@ class NormalizedValidationTask:
     task_id: str | None = None
     request_id: str | None = None
     query_variant_id: str | None = None
+    task_family: str | None = None
+    transform_id: str | None = None
+    hard_negative_count: int = 0
 
 
 def _normalize_intervals(raw_ground_truths: Any) -> GroundTruthIntervals:
@@ -82,6 +96,9 @@ def normalize_generated_task(
             task_id=generated_task.task_id,
             request_id=generated_task.request_id,
             query_variant_id=generated_task.query_variant_id,
+            task_family=generated_task.task_family,
+            transform_id=generated_task.transform_id,
+            hard_negative_count=generated_task.hard_negative_count,
         )
 
     if isinstance(generated_task, tuple) and len(generated_task) == 3:

--- a/chronoseek/validator/task_models.py
+++ b/chronoseek/validator/task_models.py
@@ -57,6 +57,8 @@ class ValidationTask:
     transform_metadata: dict[str, Any] = field(default_factory=dict)
     hard_negative_count: int = 0
     hard_negative_source_caption_ids: tuple[str, ...] = ()
+    canary_kind: str | None = None
+    expects_empty_response: bool = False
 
 
 @dataclass(frozen=True)
@@ -72,6 +74,8 @@ class NormalizedValidationTask:
     task_family: str | None = None
     transform_id: str | None = None
     hard_negative_count: int = 0
+    canary_kind: str | None = None
+    expects_empty_response: bool = False
 
 
 def _normalize_intervals(raw_ground_truths: Any) -> GroundTruthIntervals:
@@ -99,6 +103,8 @@ def normalize_generated_task(
             task_family=generated_task.task_family,
             transform_id=generated_task.transform_id,
             hard_negative_count=generated_task.hard_negative_count,
+            canary_kind=generated_task.canary_kind,
+            expects_empty_response=generated_task.expects_empty_response,
         )
 
     if isinstance(generated_task, tuple) and len(generated_task) == 3:

--- a/chronoseek/validator/task_sampler.py
+++ b/chronoseek/validator/task_sampler.py
@@ -41,6 +41,13 @@ def build_source_task_hash(
 
 
 @dataclass(frozen=True)
+class HardNegativeMoment:
+    source_caption_id: str
+    caption: str
+    ground_truths: GroundTruthIntervals
+
+
+@dataclass(frozen=True)
 class SampledActivityNetMoment:
     source_video_id: str
     source_url: str
@@ -48,6 +55,7 @@ class SampledActivityNetMoment:
     caption: str
     ground_truths: GroundTruthIntervals
     difficulty: str | None = None
+    hard_negatives: tuple[HardNegativeMoment, ...] = ()
 
 
 class ActivityNetTaskSampler:
@@ -183,6 +191,18 @@ class ActivityNetTaskSampler:
                     source_caption_id=source_caption_id,
                     now=now,
                 )
+                hard_negatives = tuple(
+                    HardNegativeMoment(
+                        source_caption_id=build_source_caption_id(
+                            source_video_id,
+                            other_caption,
+                        ),
+                        caption=other_caption,
+                        ground_truths=other_ground_truths,
+                    )
+                    for other_caption, other_ground_truths in captions
+                    if other_caption != caption
+                )
                 return (
                     SampledActivityNetMoment(
                         source_video_id=source_video_id,
@@ -191,6 +211,7 @@ class ActivityNetTaskSampler:
                         caption=caption,
                         ground_truths=ground_truths,
                         difficulty=video.get("difficulty"),
+                        hard_negatives=hard_negatives,
                     ),
                     rng,
                 )

--- a/chronoseek/validator/telemetry.py
+++ b/chronoseek/validator/telemetry.py
@@ -1,4 +1,5 @@
 import json
+import math
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -38,6 +39,7 @@ class MinerTelemetrySummary:
     failures: int = 0
     timeouts: int = 0
     total_score: float = 0.0
+    total_score_squared: float = 0.0
     total_latency: float = 0.0
     canary_attempts: int = 0
     canary_score: float = 0.0
@@ -46,7 +48,9 @@ class MinerTelemetrySummary:
 
     def record(self, event: MinerTelemetryEvent) -> None:
         self.attempts += 1
-        self.total_score += float(event.score)
+        score = float(event.score)
+        self.total_score += score
+        self.total_score_squared += score * score
         self.total_latency += max(0.0, float(event.latency))
         if event.failed:
             self.failures += 1
@@ -66,6 +70,14 @@ class MinerTelemetrySummary:
     @property
     def average_score(self) -> float:
         return self.total_score / self.attempts if self.attempts else 0.0
+
+    @property
+    def score_stddev(self) -> float:
+        if self.attempts <= 1:
+            return 0.0
+        mean = self.average_score
+        variance = max(0.0, (self.total_score_squared / self.attempts) - (mean * mean))
+        return math.sqrt(variance)
 
     @property
     def average_latency(self) -> float:
@@ -112,6 +124,7 @@ class MinerTelemetrySummary:
             "failures": self.failures,
             "timeouts": self.timeouts,
             "average_score": self.average_score,
+            "score_stddev": self.score_stddev,
             "average_latency": self.average_latency,
             "error_rate": self.error_rate,
             "timeout_rate": self.timeout_rate,

--- a/chronoseek/validator/telemetry.py
+++ b/chronoseek/validator/telemetry.py
@@ -1,0 +1,155 @@
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MinerTelemetryEvent:
+    uid: int
+    score: float
+    latency: float
+    task_family: str
+    canary_kind: str | None = None
+    transform_id: str | None = None
+    hard_negative_count: int = 0
+    failure_kind: str | None = None
+    protocol_code: str | None = None
+    status_code: int | None = None
+    top_start: float | None = None
+    top_end: float | None = None
+    created_at: float = field(default_factory=time.time)
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.failure_kind)
+
+    @property
+    def prediction_duration(self) -> float | None:
+        if self.top_start is None or self.top_end is None:
+            return None
+        return max(0.0, float(self.top_end) - float(self.top_start))
+
+
+@dataclass
+class MinerTelemetrySummary:
+    uid: int
+    attempts: int = 0
+    failures: int = 0
+    timeouts: int = 0
+    total_score: float = 0.0
+    total_latency: float = 0.0
+    canary_attempts: int = 0
+    canary_score: float = 0.0
+    hard_negative_attempts: int = 0
+    duration_buckets: dict[str, int] = field(default_factory=dict)
+
+    def record(self, event: MinerTelemetryEvent) -> None:
+        self.attempts += 1
+        self.total_score += float(event.score)
+        self.total_latency += max(0.0, float(event.latency))
+        if event.failed:
+            self.failures += 1
+        if event.failure_kind == "timeout":
+            self.timeouts += 1
+        if event.canary_kind:
+            self.canary_attempts += 1
+            self.canary_score += float(event.score)
+        if int(event.hard_negative_count) > 0:
+            self.hard_negative_attempts += 1
+
+        duration = event.prediction_duration
+        if duration is not None:
+            bucket = f"{round(duration, 1):.1f}"
+            self.duration_buckets[bucket] = self.duration_buckets.get(bucket, 0) + 1
+
+    @property
+    def average_score(self) -> float:
+        return self.total_score / self.attempts if self.attempts else 0.0
+
+    @property
+    def average_latency(self) -> float:
+        return self.total_latency / self.attempts if self.attempts else 0.0
+
+    @property
+    def error_rate(self) -> float:
+        return self.failures / self.attempts if self.attempts else 0.0
+
+    @property
+    def timeout_rate(self) -> float:
+        return self.timeouts / self.attempts if self.attempts else 0.0
+
+    @property
+    def average_canary_score(self) -> float:
+        return self.canary_score / self.canary_attempts if self.canary_attempts else 0.0
+
+    @property
+    def dominant_duration_rate(self) -> float:
+        if not self.duration_buckets:
+            return 0.0
+        return max(self.duration_buckets.values()) / sum(self.duration_buckets.values())
+
+    def suspicion_flags(self) -> list[str]:
+        flags: list[str] = []
+        if self.attempts >= 5 and self.error_rate >= 0.50:
+            flags.append("high_error_rate")
+        if self.attempts >= 5 and self.timeout_rate >= 0.25:
+            flags.append("high_timeout_rate")
+        if sum(self.duration_buckets.values()) >= 5 and self.dominant_duration_rate >= 0.80:
+            flags.append("repeated_prediction_duration")
+        if (
+            self.canary_attempts >= 3
+            and self.average_score >= 0.50
+            and self.average_canary_score <= 0.10
+        ):
+            flags.append("canary_underperformance")
+        return flags
+
+    def to_dict(self) -> dict:
+        return {
+            "uid": self.uid,
+            "attempts": self.attempts,
+            "failures": self.failures,
+            "timeouts": self.timeouts,
+            "average_score": self.average_score,
+            "average_latency": self.average_latency,
+            "error_rate": self.error_rate,
+            "timeout_rate": self.timeout_rate,
+            "canary_attempts": self.canary_attempts,
+            "average_canary_score": self.average_canary_score,
+            "hard_negative_attempts": self.hard_negative_attempts,
+            "dominant_duration_rate": self.dominant_duration_rate,
+            "duration_buckets": dict(sorted(self.duration_buckets.items())),
+            "suspicion_flags": self.suspicion_flags(),
+        }
+
+
+class ValidatorTelemetryState:
+    def __init__(self, *, max_events: int = 1000):
+        self.max_events = max(1, int(max_events))
+        self.events: list[MinerTelemetryEvent] = []
+        self.summaries: dict[int, MinerTelemetrySummary] = {}
+
+    def record(self, event: MinerTelemetryEvent) -> None:
+        self.events.append(event)
+        if len(self.events) > self.max_events:
+            self.events = self.events[-self.max_events :]
+
+        uid = int(event.uid)
+        summary = self.summaries.setdefault(uid, MinerTelemetrySummary(uid=uid))
+        summary.record(event)
+
+    def snapshot(self) -> dict:
+        return {
+            "generated_at": time.time(),
+            "events": [asdict(event) for event in self.events],
+            "summaries": {
+                str(uid): summary.to_dict()
+                for uid, summary in sorted(self.summaries.items())
+            },
+        }
+
+    def save_json(self, path: str | Path) -> None:
+        output_path = Path(path).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(self.snapshot(), indent=2, sort_keys=True))

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -17,6 +17,8 @@ The target flow is:
 5. The validator uploads the task clip to Hippius public S3.
 6. The validator sends miners only the Hippius URL, query variant, request ID, protocol version, and `top_k=1`.
 7. The validator scores miner responses against clip-local shifted ground truths.
+8. At a configurable low rate, the validator converts hardened tasks into
+   internal canaries for absent, hard-negative, or repeated-moment probes.
 
 ActivityNet remains the source of truth. Original ActivityNet source URLs, source video IDs, raw captions, and ground-truth timestamps must not be sent to miners or logged at INFO level.
 
@@ -359,6 +361,8 @@ Tests:
   in cropped task clips.
 - Randomized encoding transform IDs are recorded on internal tasks and included
   in replay identity.
+- Absent canaries can reward successful empty responses without rewarding
+  timeouts, protocol errors, or ordinary empty responses.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -367,6 +367,8 @@ Tests:
   timeouts, protocol errors, or ordinary empty responses.
 - Miner telemetry summaries and suspicion flags are deterministic and
   report-only until a weight aggregation policy explicitly consumes them.
+- Score aggregation exposes quality, reliability, consistency, and suspicion
+  components with opt-in post-quality multiplier weights.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -21,6 +21,8 @@ The target flow is:
    internal canaries for absent, hard-negative, or repeated-moment probes.
 9. The validator records report-only miner telemetry for score, latency,
    failures, task family, canaries, transforms, and repeated prediction shapes.
+10. The artifact manifest tracks active exposure counts so validators can limit
+    reuse of source videos, captions, query variants, and transform profiles.
 
 ActivityNet remains the source of truth. Original ActivityNet source URLs, source video IDs, raw captions, and ground-truth timestamps must not be sent to miners or logged at INFO level.
 
@@ -369,6 +371,8 @@ Tests:
   report-only until a weight aggregation policy explicitly consumes them.
 - Score aggregation exposes quality, reliability, consistency, and suspicion
   components with opt-in post-quality multiplier weights.
+- Active task exposure limits can block repeated source/caption/query/transform
+  use while previous artifacts remain live.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -339,6 +339,8 @@ Tests:
   localizations.
 - Apply boundary, center, and duration alignment penalties after selecting the
   best valid top-1 prediction/ground-truth pair.
+- Optionally apply a gentle latency multiplier after quality scoring; fast bad
+  answers must not outrank accurate answers by speed alone.
 - Score only the first valid result.
 - Ignore confidence for validator weights.
 - Zero invalid responses:
@@ -373,6 +375,8 @@ Tests:
   components with opt-in post-quality multiplier weights.
 - Active task exposure limits can block repeated source/caption/query/transform
   use while previous artifacts remain live.
+- Optional latency multipliers preserve zero scores and only dampen otherwise
+  valid quality scores.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -326,7 +326,11 @@ Tests:
 
 ### 9. Harden Scoring
 
-- Keep continuous IoU as the primary score.
+- Keep continuous IoU as the primary score, but dampen it with interval-shape
+  penalties so loose overlapping windows do not score as well as tight
+  localizations.
+- Apply boundary, center, and duration alignment penalties after selecting the
+  best valid top-1 prediction/ground-truth pair.
 - Score only the first valid result.
 - Ignore confidence for validator weights.
 - Zero invalid responses:
@@ -344,6 +348,10 @@ Tests:
 Tests:
 
 - Correct clip-local prediction scores by IoU.
+- Broad center-aligned intervals score below tighter intervals with comparable
+  overlap.
+- Center-missed intervals score below center-aligned intervals with comparable
+  overlap.
 - Original ActivityNet timestamp does not score correctly after clipping.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -19,6 +19,8 @@ The target flow is:
 7. The validator scores miner responses against clip-local shifted ground truths.
 8. At a configurable low rate, the validator converts hardened tasks into
    internal canaries for absent, hard-negative, or repeated-moment probes.
+9. The validator records report-only miner telemetry for score, latency,
+   failures, task family, canaries, transforms, and repeated prediction shapes.
 
 ActivityNet remains the source of truth. Original ActivityNet source URLs, source video IDs, raw captions, and ground-truth timestamps must not be sent to miners or logged at INFO level.
 
@@ -363,6 +365,8 @@ Tests:
   in replay identity.
 - Absent canaries can reward successful empty responses without rewarding
   timeouts, protocol errors, or ordinary empty responses.
+- Miner telemetry summaries and suspicion flags are deterministic and
+  report-only until a weight aggregation policy explicitly consumes them.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/VALIDATOR_ANTI_GAMING_TASKS.md
+++ b/docs/VALIDATOR_ANTI_GAMING_TASKS.md
@@ -10,8 +10,10 @@ The target flow is:
 
 1. The validator samples ActivityNet internally.
 2. The validator selects one caption group and its ground-truth intervals.
-3. The validator creates a private cropped clip around the target moment.
-4. The validator re-encodes/compresses the clip to strip metadata and reduce size.
+3. The validator creates a private cropped clip around the target moment, adding
+   same-video hard negatives when they fit inside the configured duration budget.
+4. The validator re-encodes/compresses the clip with a randomized transform
+   profile to strip metadata, vary resolution/bitrate, and reduce size.
 5. The validator uploads the task clip to Hippius public S3.
 6. The validator sends miners only the Hippius URL, query variant, request ID, protocol version, and `top_k=1`.
 7. The validator scores miner responses against clip-local shifted ground truths.
@@ -353,6 +355,10 @@ Tests:
 - Center-missed intervals score below center-aligned intervals with comparable
   overlap.
 - Original ActivityNet timestamp does not score correctly after clipping.
+- Same-video hard-negative candidates are tracked internally and can be included
+  in cropped task clips.
+- Randomized encoding transform IDs are recorded on internal tasks and included
+  in replay identity.
 - Invalid intervals score zero.
 - Oversized intervals score zero unless the matching ground-truth span is longer.
 - Extra results beyond top-1 do not improve score.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -160,6 +160,9 @@ For restricted videos, configure cookies:
 | `MAX_ACTIVE_TASKS_PER_TRANSFORM` | `0` | Maximum active hardened artifacts per transform profile; `0` disables the limit. |
 | `VALIDATOR_EVAL_TOP_K` | `1` | Number of miner results requested and scored. |
 | `TASK_MAX_PREDICTION_DURATION_SECONDS` | `60` | Maximum scored prediction duration unless ground truth is longer. |
+| `ENABLE_LATENCY_MULTIPLIER` | `0` | Applies a gentle post-quality latency multiplier when enabled. |
+| `LATENCY_GRACE_SECONDS` | `30` | Latency before the optional multiplier begins decaying. |
+| `LATENCY_MIN_MULTIPLIER` | `0.85` | Lowest optional multiplier near the miner request timeout. |
 | `SCORE_EMA_ALPHA` | `0.1` | EMA alpha used for instant miner quality scores. |
 | `SCORE_RELIABILITY_WEIGHT` | `0` | Optional post-quality reliability multiplier weight. |
 | `SCORE_CONSISTENCY_WEIGHT` | `0` | Optional post-quality consistency multiplier weight. |
@@ -211,6 +214,12 @@ dampened for sloppy interval shape:
 Malformed intervals, empty responses, timeouts, out-of-clip intervals, and
 oversized intervals still score zero. Extra results beyond the validator's
 configured top-k do not improve the score.
+
+When `ENABLE_LATENCY_MULTIPLIER=1`, the interval quality score is multiplied by
+a gentle latency factor. The multiplier is `1.0` through
+`LATENCY_GRACE_SECONDS`, then decays toward `LATENCY_MIN_MULTIPLIER` near
+`MINER_REQUEST_TIMEOUT_SECONDS`. A zero-quality response remains zero
+regardless of latency.
 
 ## Adversarial Task Transforms
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -152,6 +152,8 @@ For restricted videos, configure cookies:
 | `TASK_SOURCE_DOWNLOAD_TIMEOUT_SECONDS` | `120` | Source download timeout for clipping. |
 | `ENABLE_ADVERSARIAL_TASK_TRANSFORMS` | `1` | Enables randomized context and encoding transforms for hardened tasks. |
 | `ENABLE_TASK_ENCODING_PROFILE_VARIANTS` | `1` | Enables compact/detail encoding variants for hardened clips. |
+| `CANARY_TASK_RATE` | `0` | Fraction of hardened tasks converted into internal canary tasks. |
+| `ABSENT_CANARY_QUERIES` | Empty | Optional pipe-separated absent-query canary prompts. |
 | `VALIDATOR_EVAL_TOP_K` | `1` | Number of miner results requested and scored. |
 | `TASK_MAX_PREDICTION_DURATION_SECONDS` | `60` | Maximum scored prediction duration unless ground truth is longer. |
 | `MINER_REQUEST_TIMEOUT_SECONDS` | `150` | Per-miner `/search` timeout. |
@@ -208,3 +210,16 @@ clip when another annotated moment fits inside the configured maximum duration.
 The generator also records the selected encoding transform profile and context
 padding metadata on the internal `ValidationTask`. Miners still receive only
 the artifact URL, query, request ID, protocol version, and `top_k`.
+
+## Canary Tasks
+
+Canaries are internal validator probes sampled from hardened tasks at
+`CANARY_TASK_RATE`. The initial canary types are:
+
+- `absent`: replaces the query with an unlikely absent event, clears ground
+  truth, and expects an empty successful response.
+- `hard-negative`: tags clips containing same-video distractor moments.
+- `repeated`: tags tasks with multiple valid target intervals.
+
+Timeouts, protocol errors, and failed requests are never rewarded as absent
+canaries; only a successful empty response can receive the absent-canary score.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -180,6 +180,21 @@ For restricted videos, configure cookies:
 ## Operational Notes
 
 - Do not send original ActivityNet source URLs, source video IDs, raw captions, or ground-truth timestamps to miners.
+
+## Interval Scoring
+
+Validator scoring is still accuracy-first and protocol-compatible, but the
+default score is now shape-aware interval quality rather than raw IoU alone.
+The best valid top-1 prediction/ground-truth pair is scored by IoU, then
+dampened for sloppy interval shape:
+
+- center alignment: prediction center should land near the target moment center
+- boundary alignment: start and end should closely match the ground truth
+- duration alignment: broad windows are penalized even when they overlap
+
+Malformed intervals, empty responses, timeouts, out-of-clip intervals, and
+oversized intervals still score zero. Extra results beyond the validator's
+configured top-k do not improve the score.
 - Keep `VALIDATOR_TASK_SECRET`, Hippius credentials, Chutes credentials, and Vidaio credentials out of committed files.
 - Hardened task generation increases validator-side CPU, disk, network, and storage usage.
 - See [Owner and development guide](./development.md) for live module checks.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -156,6 +156,10 @@ For restricted videos, configure cookies:
 | `ABSENT_CANARY_QUERIES` | Empty | Optional pipe-separated absent-query canary prompts. |
 | `VALIDATOR_EVAL_TOP_K` | `1` | Number of miner results requested and scored. |
 | `TASK_MAX_PREDICTION_DURATION_SECONDS` | `60` | Maximum scored prediction duration unless ground truth is longer. |
+| `SCORE_EMA_ALPHA` | `0.1` | EMA alpha used for instant miner quality scores. |
+| `SCORE_RELIABILITY_WEIGHT` | `0` | Optional post-quality reliability multiplier weight. |
+| `SCORE_CONSISTENCY_WEIGHT` | `0` | Optional post-quality consistency multiplier weight. |
+| `SCORE_SUSPICION_WEIGHT` | `0` | Optional post-quality suspicion multiplier weight. |
 | `MINER_REQUEST_TIMEOUT_SECONDS` | `150` | Per-miner `/search` timeout. |
 | `MINER_SUBMISSION_CACHE_TTL_SECONDS` | `300` | Chain submission cache TTL. |
 | `MINER_SUBMISSION_REFRESH_INTERVAL_SECONDS` | `60` | Miner submission refresh interval. |
@@ -232,3 +236,12 @@ to `VALIDATOR_TELEMETRY_PATH`. The snapshot includes per-miner score, latency,
 failure, timeout, task-family, canary, hard-negative, and repeated-duration
 signals. Suspicion flags are logged for visibility but do not affect weights
 until an aggregation policy explicitly consumes them.
+
+## Score Aggregation
+
+The validator now computes explicit quality, reliability, consistency, and
+suspicion components before updating moving scores. By default only the quality
+EMA is active, matching the previous `alpha = 0.1` behavior. Setting
+`SCORE_RELIABILITY_WEIGHT`, `SCORE_CONSISTENCY_WEIGHT`, or
+`SCORE_SUSPICION_WEIGHT` above zero turns on post-quality multipliers based on
+the telemetry summary for each miner.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -154,6 +154,10 @@ For restricted videos, configure cookies:
 | `ENABLE_TASK_ENCODING_PROFILE_VARIANTS` | `1` | Enables compact/detail encoding variants for hardened clips. |
 | `CANARY_TASK_RATE` | `0` | Fraction of hardened tasks converted into internal canary tasks. |
 | `ABSENT_CANARY_QUERIES` | Empty | Optional pipe-separated absent-query canary prompts. |
+| `MAX_ACTIVE_TASKS_PER_SOURCE_VIDEO` | `0` | Maximum active hardened artifacts per source video; `0` disables the limit. |
+| `MAX_ACTIVE_TASKS_PER_SOURCE_CAPTION` | `0` | Maximum active hardened artifacts per source caption; `0` disables the limit. |
+| `MAX_ACTIVE_TASKS_PER_QUERY_VARIANT` | `0` | Maximum active hardened artifacts per query variant; `0` disables the limit. |
+| `MAX_ACTIVE_TASKS_PER_TRANSFORM` | `0` | Maximum active hardened artifacts per transform profile; `0` disables the limit. |
 | `VALIDATOR_EVAL_TOP_K` | `1` | Number of miner results requested and scored. |
 | `TASK_MAX_PREDICTION_DURATION_SECONDS` | `60` | Maximum scored prediction duration unless ground truth is longer. |
 | `SCORE_EMA_ALPHA` | `0.1` | EMA alpha used for instant miner quality scores. |
@@ -228,6 +232,14 @@ Canaries are internal validator probes sampled from hardened tasks at
 
 Timeouts, protocol errors, and failed requests are never rewarded as absent
 canaries; only a successful empty response can receive the absent-canary score.
+
+## Task Exposure Controls
+
+The artifact manifest records source video, source caption, query variant,
+transform profile, crop bucket, and task family for active generated clips.
+Validators can set `MAX_ACTIVE_TASKS_PER_*` limits to reduce repeated exposure
+while task artifacts remain active. The local hardened-task verifier prints an
+exposure summary so operators can inspect active task-bank freshness.
 
 ## Telemetry
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -160,6 +160,7 @@ For restricted videos, configure cookies:
 | `MINER_SUBMISSION_CACHE_TTL_SECONDS` | `300` | Chain submission cache TTL. |
 | `MINER_SUBMISSION_REFRESH_INTERVAL_SECONDS` | `60` | Miner submission refresh interval. |
 | `MINER_SUBMISSION_HEALTH_TIMEOUT_SECONDS` | `10` | Per-runtime `/health` timeout. |
+| `VALIDATOR_TELEMETRY_PATH` | Empty | Optional JSON path for miner behavior telemetry snapshots. |
 | `MINER_EMISSION_BURN_PERCENT` | `0` | Percent of emissions assigned to UID 0 burn. |
 
 ## Hippius Configuration
@@ -223,3 +224,11 @@ Canaries are internal validator probes sampled from hardened tasks at
 
 Timeouts, protocol errors, and failed requests are never rewarded as absent
 canaries; only a successful empty response can receive the absent-canary score.
+
+## Telemetry
+
+Validators keep report-only miner behavior telemetry in memory and can write it
+to `VALIDATOR_TELEMETRY_PATH`. The snapshot includes per-miner score, latency,
+failure, timeout, task-family, canary, hard-negative, and repeated-duration
+signals. Suspicion flags are logged for visibility but do not affect weights
+until an aggregation policy explicitly consumes them.

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -150,6 +150,8 @@ For restricted videos, configure cookies:
 | `TASK_MIN_CLIP_DURATION_SECONDS` | `30` | Minimum generated clip duration. |
 | `TASK_MAX_CLIP_DURATION_SECONDS` | `180` | Maximum generated clip duration. |
 | `TASK_SOURCE_DOWNLOAD_TIMEOUT_SECONDS` | `120` | Source download timeout for clipping. |
+| `ENABLE_ADVERSARIAL_TASK_TRANSFORMS` | `1` | Enables randomized context and encoding transforms for hardened tasks. |
+| `ENABLE_TASK_ENCODING_PROFILE_VARIANTS` | `1` | Enables compact/detail encoding variants for hardened clips. |
 | `VALIDATOR_EVAL_TOP_K` | `1` | Number of miner results requested and scored. |
 | `TASK_MAX_PREDICTION_DURATION_SECONDS` | `60` | Maximum scored prediction duration unless ground truth is longer. |
 | `MINER_REQUEST_TIMEOUT_SECONDS` | `150` | Per-miner `/search` timeout. |
@@ -180,6 +182,9 @@ For restricted videos, configure cookies:
 ## Operational Notes
 
 - Do not send original ActivityNet source URLs, source video IDs, raw captions, or ground-truth timestamps to miners.
+- Keep `VALIDATOR_TASK_SECRET`, Hippius credentials, Chutes credentials, and Vidaio credentials out of committed files.
+- Hardened task generation increases validator-side CPU, disk, network, and storage usage.
+- See [Owner and development guide](./development.md) for live module checks.
 
 ## Interval Scoring
 
@@ -195,6 +200,11 @@ dampened for sloppy interval shape:
 Malformed intervals, empty responses, timeouts, out-of-clip intervals, and
 oversized intervals still score zero. Extra results beyond the validator's
 configured top-k do not improve the score.
-- Keep `VALIDATOR_TASK_SECRET`, Hippius credentials, Chutes credentials, and Vidaio credentials out of committed files.
-- Hardened task generation increases validator-side CPU, disk, network, and storage usage.
-- See [Owner and development guide](./development.md) for live module checks.
+
+## Adversarial Task Transforms
+
+Hardened task generation can include same-video hard-negative moments in the
+clip when another annotated moment fits inside the configured maximum duration.
+The generator also records the selected encoding transform profile and context
+padding metadata on the internal `ValidationTask`. Miners still receive only
+the artifact URL, query, request ID, protocol version, and `top_k`.

--- a/scripts/verify_hardened_task_generation.py
+++ b/scripts/verify_hardened_task_generation.py
@@ -214,6 +214,30 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.getenv("TASK_CLIP_AUDIO_BITRATE", "96k"),
     )
     parser.add_argument(
+        "--enable-adversarial-task-transforms",
+        action="store_true",
+        default=env_bool("ENABLE_ADVERSARIAL_TASK_TRANSFORMS", True),
+        help="Enable randomized hardened task transforms.",
+    )
+    parser.add_argument(
+        "--disable-adversarial-task-transforms",
+        action="store_false",
+        dest="enable_adversarial_task_transforms",
+        help="Disable randomized hardened task transforms.",
+    )
+    parser.add_argument(
+        "--enable-task-encoding-profile-variants",
+        action="store_true",
+        default=env_bool("ENABLE_TASK_ENCODING_PROFILE_VARIANTS", True),
+        help="Enable randomized encoding profile variants.",
+    )
+    parser.add_argument(
+        "--disable-task-encoding-profile-variants",
+        action="store_false",
+        dest="enable_task_encoding_profile_variants",
+        help="Disable randomized encoding profile variants.",
+    )
+    parser.add_argument(
         "--use-vidaio",
         action="store_true",
         default=env_bool("VIDAIO_COMPRESSION_ENABLED", False),
@@ -408,6 +432,8 @@ def build_generator(args: argparse.Namespace):
             cleanup_interval_seconds=0,
             max_generation_attempts=args.max_generation_attempts,
             delete_remote_artifacts=False,
+            enable_adversarial_transforms=args.enable_adversarial_task_transforms,
+            enable_encoding_profile_variants=args.enable_task_encoding_profile_variants,
         ),
     )
     return {
@@ -474,6 +500,8 @@ def main() -> int:
                 "ephemeral_secret_used": context["ephemeral_secret"],
                 "manifest_path": str(manifest.path),
                 "storage": "hippius" if args.upload_to_hippius else "local-dry-run",
+                "adversarial_transforms": args.enable_adversarial_task_transforms,
+                "encoding_profile_variants": args.enable_task_encoding_profile_variants,
                 "generated_at": iso_timestamp(time.time()),
             },
         )

--- a/scripts/verify_hardened_task_generation.py
+++ b/scripts/verify_hardened_task_generation.py
@@ -249,6 +249,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pipe-separated absent-query canary prompts.",
     )
     parser.add_argument(
+        "--max-active-tasks-per-source-video",
+        type=int,
+        default=env_int("MAX_ACTIVE_TASKS_PER_SOURCE_VIDEO", 0),
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-source-caption",
+        type=int,
+        default=env_int("MAX_ACTIVE_TASKS_PER_SOURCE_CAPTION", 0),
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-query-variant",
+        type=int,
+        default=env_int("MAX_ACTIVE_TASKS_PER_QUERY_VARIANT", 0),
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-transform",
+        type=int,
+        default=env_int("MAX_ACTIVE_TASKS_PER_TRANSFORM", 0),
+    )
+    parser.add_argument(
         "--use-vidaio",
         action="store_true",
         default=env_bool("VIDAIO_COMPRESSION_ENABLED", False),
@@ -452,6 +472,10 @@ def build_generator(args: argparse.Namespace):
                 if query.strip()
             )
             or HardenedTaskGeneratorConfig.absent_canary_queries,
+            max_active_tasks_per_source_video=args.max_active_tasks_per_source_video,
+            max_active_tasks_per_source_caption=args.max_active_tasks_per_source_caption,
+            max_active_tasks_per_query_variant=args.max_active_tasks_per_query_variant,
+            max_active_tasks_per_transform=args.max_active_tasks_per_transform,
         ),
     )
     return {
@@ -521,6 +545,7 @@ def main() -> int:
                 "adversarial_transforms": args.enable_adversarial_task_transforms,
                 "encoding_profile_variants": args.enable_task_encoding_profile_variants,
                 "canary_task_rate": args.canary_task_rate,
+                "exposure_summary": manifest.exposure_summary(now=time.time()),
                 "generated_at": iso_timestamp(time.time()),
             },
         )

--- a/scripts/verify_hardened_task_generation.py
+++ b/scripts/verify_hardened_task_generation.py
@@ -238,6 +238,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Disable randomized encoding profile variants.",
     )
     parser.add_argument(
+        "--canary-task-rate",
+        type=float,
+        default=env_float("CANARY_TASK_RATE", 0.0),
+        help="Fraction of hardened tasks converted into internal validator canaries.",
+    )
+    parser.add_argument(
+        "--absent-canary-queries",
+        default=os.getenv("ABSENT_CANARY_QUERIES", ""),
+        help="Pipe-separated absent-query canary prompts.",
+    )
+    parser.add_argument(
         "--use-vidaio",
         action="store_true",
         default=env_bool("VIDAIO_COMPRESSION_ENABLED", False),
@@ -434,6 +445,13 @@ def build_generator(args: argparse.Namespace):
             delete_remote_artifacts=False,
             enable_adversarial_transforms=args.enable_adversarial_task_transforms,
             enable_encoding_profile_variants=args.enable_task_encoding_profile_variants,
+            canary_task_rate=args.canary_task_rate,
+            absent_canary_queries=tuple(
+                query.strip()
+                for query in str(args.absent_canary_queries or "").split("|")
+                if query.strip()
+            )
+            or HardenedTaskGeneratorConfig.absent_canary_queries,
         ),
     )
     return {
@@ -502,6 +520,7 @@ def main() -> int:
                 "storage": "hippius" if args.upload_to_hippius else "local-dry-run",
                 "adversarial_transforms": args.enable_adversarial_task_transforms,
                 "encoding_profile_variants": args.enable_task_encoding_profile_variants,
+                "canary_task_rate": args.canary_task_rate,
                 "generated_at": iso_timestamp(time.time()),
             },
         )

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -97,6 +97,19 @@ class TestScoring(unittest.TestCase):
             interval_quality_score(broad_centered, gt),
         )
 
+    def test_absent_canary_scoring_rewards_only_empty_predictions(self):
+        pred = [VideoSearchResult(start=10.0, end=20.0, confidence=0.9)]
+
+        self.assertEqual(
+            score_response([], [], 0.1, expects_empty_response=True),
+            1.0,
+        )
+        self.assertEqual(
+            score_response(pred, [], 0.1, expects_empty_response=True),
+            0.0,
+        )
+        self.assertEqual(score_response([], [], 0.1), 0.0)
+
     def test_strict_threshold_helper(self):
         self.assertTrue(passes_strict_iou(STRICT_IOU_THRESHOLD))
         self.assertFalse(passes_strict_iou(STRICT_IOU_THRESHOLD - 0.01))

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -1,8 +1,10 @@
 import unittest
 from chronoseek.scoring import (
     STRICT_IOU_THRESHOLD,
+    PURE_IOU_SCORING,
     best_iou,
     calculate_iou,
+    interval_quality_score,
     passes_strict_iou,
     score_response,
 )
@@ -35,23 +37,20 @@ class TestScoring(unittest.TestCase):
         self.assertAlmostEqual(calculate_iou(10, 15, 0, 20), 0.25)
 
     def test_scoring_rules(self):
-        """Test continuous IoU scoring rules"""
+        """Test continuous shape-aware interval scoring rules"""
 
         gt = (10.0, 20.0)
 
-        # Case A: High IoU (>0.5) -> score equals best IoU
-        # Pred: 11-19 (IoU should be high)
-        # Int: 8, Union: 10. IoU=0.8
+        # Case A: High IoU, center-aligned, slightly trimmed boundaries.
         pred_pass = [VideoSearchResult(start=11.0, end=19.0, confidence=0.9)]
-        self.assertAlmostEqual(score_response(pred_pass, gt, 0.1), 0.8)
+        self.assertGreater(score_response(pred_pass, gt, 0.1), 0.75)
+        self.assertLess(score_response(pred_pass, gt, 0.1), 0.8)
 
-        # Case B: Low IoU (<0.5) -> score equals best IoU
-        # Pred: 0-12
-        # Int: 2 (10-12), Union: 20 (0-20). IoU=0.1
+        # Case B: Low IoU is dampened further by center and boundary misses.
         pred_fail = [VideoSearchResult(start=0.0, end=12.0, confidence=0.9)]
-        self.assertAlmostEqual(score_response(pred_fail, gt, 0.1), 0.1)
+        self.assertLess(score_response(pred_fail, gt, 0.1), 0.1)
 
-        # Case C: Multiple predictions, take max IoU
+        # Case C: Multiple predictions, take max quality
         preds_mixed = [
             VideoSearchResult(start=0.0, end=5.0, confidence=0.5),  # IoU 0
             VideoSearchResult(start=10.0, end=20.0, confidence=0.8),  # IoU 1.0
@@ -65,8 +64,38 @@ class TestScoring(unittest.TestCase):
         preds = [VideoSearchResult(start=30.0, end=40.0, confidence=0.9)]
         ground_truths = [(10.0, 20.0), (31.0, 39.0)]
 
-        self.assertAlmostEqual(score_response(preds, ground_truths, 0.1), 0.8)
+        self.assertGreater(score_response(preds, ground_truths, 0.1), 0.75)
+        self.assertLess(score_response(preds, ground_truths, 0.1), 0.8)
         self.assertAlmostEqual(best_iou(preds, ground_truths), 0.8)
+
+    def test_pure_iou_scoring_config_keeps_legacy_score(self):
+        preds = [VideoSearchResult(start=11.0, end=19.0, confidence=0.9)]
+
+        self.assertAlmostEqual(
+            score_response(
+                preds,
+                (10.0, 20.0),
+                0.1,
+                interval_scoring_config=PURE_IOU_SCORING,
+            ),
+            0.8,
+        )
+
+    def test_shape_penalties_lower_broad_and_center_missed_intervals(self):
+        gt = (10.0, 20.0)
+        perfect = VideoSearchResult(start=10.0, end=20.0, confidence=0.9)
+        broad_centered = VideoSearchResult(start=5.0, end=25.0, confidence=0.9)
+        center_missed = VideoSearchResult(start=5.0, end=15.0, confidence=0.9)
+
+        self.assertEqual(interval_quality_score(perfect, gt), 1.0)
+        self.assertLess(
+            interval_quality_score(broad_centered, gt),
+            calculate_iou(5.0, 25.0, 10.0, 20.0),
+        )
+        self.assertLess(
+            interval_quality_score(center_missed, gt),
+            interval_quality_score(broad_centered, gt),
+        )
 
     def test_strict_threshold_helper(self):
         self.assertTrue(passes_strict_iou(STRICT_IOU_THRESHOLD))

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -1,9 +1,11 @@
 import unittest
 from chronoseek.scoring import (
+    LatencyScoringConfig,
     STRICT_IOU_THRESHOLD,
     PURE_IOU_SCORING,
     best_iou,
     calculate_iou,
+    calculate_latency_multiplier,
     interval_quality_score,
     passes_strict_iou,
     score_response,
@@ -109,6 +111,50 @@ class TestScoring(unittest.TestCase):
             0.0,
         )
         self.assertEqual(score_response([], [], 0.1), 0.0)
+
+    def test_latency_multiplier_is_optional_and_gentle(self):
+        disabled = LatencyScoringConfig(enabled=False)
+        enabled = LatencyScoringConfig(
+            enabled=True,
+            grace_seconds=10.0,
+            timeout_seconds=100.0,
+            min_multiplier=0.8,
+        )
+
+        self.assertEqual(calculate_latency_multiplier(100.0, config=disabled), 1.0)
+        self.assertEqual(calculate_latency_multiplier(5.0, config=enabled), 1.0)
+        self.assertEqual(calculate_latency_multiplier(100.0, config=enabled), 0.8)
+        self.assertGreater(calculate_latency_multiplier(55.0, config=enabled), 0.8)
+
+    def test_latency_multiplier_preserves_quality_ordering(self):
+        latency_config = LatencyScoringConfig(
+            enabled=True,
+            grace_seconds=0.0,
+            timeout_seconds=100.0,
+            min_multiplier=0.85,
+        )
+        slow_perfect = [
+            VideoSearchResult(start=10.0, end=20.0, confidence=0.9),
+        ]
+        fast_poor = [
+            VideoSearchResult(start=0.0, end=12.0, confidence=0.9),
+        ]
+
+        slow_score = score_response(
+            slow_perfect,
+            (10.0, 20.0),
+            100.0,
+            latency_scoring_config=latency_config,
+        )
+        fast_score = score_response(
+            fast_poor,
+            (10.0, 20.0),
+            0.1,
+            latency_scoring_config=latency_config,
+        )
+
+        self.assertEqual(score_response([], (10.0, 20.0), 0.1), 0.0)
+        self.assertGreater(slow_score, fast_score)
 
     def test_strict_threshold_helper(self):
         self.assertTrue(passes_strict_iou(STRICT_IOU_THRESHOLD))

--- a/tests/unit/test_validator_aggregation.py
+++ b/tests/unit/test_validator_aggregation.py
@@ -1,0 +1,75 @@
+import pytest
+
+from chronoseek.validator.aggregation import (
+    ScoreAggregationConfig,
+    update_miner_score,
+)
+from chronoseek.validator.telemetry import MinerTelemetryEvent, ValidatorTelemetryState
+
+
+def test_score_aggregation_default_reproduces_quality_ema():
+    components = update_miner_score(
+        previous_score=0.4,
+        instant_score=1.0,
+        telemetry_summary=None,
+        config=ScoreAggregationConfig(alpha=0.1),
+    )
+
+    assert components.quality_score == pytest.approx(0.46)
+    assert components.final_score == pytest.approx(0.46)
+    assert components.reliability_score == 1.0
+    assert components.consistency_score == 1.0
+    assert components.suspicion_score == 1.0
+
+
+def test_score_aggregation_can_apply_reliability_penalty():
+    telemetry = ValidatorTelemetryState()
+    for _ in range(5):
+        telemetry.record(
+            MinerTelemetryEvent(
+                uid=1,
+                score=0.0,
+                latency=10.0,
+                task_family="hardened-activitynet",
+                failure_kind="timeout",
+            )
+        )
+
+    components = update_miner_score(
+        previous_score=0.5,
+        instant_score=1.0,
+        telemetry_summary=telemetry.summaries[1],
+        config=ScoreAggregationConfig(
+            alpha=0.1,
+            reliability_weight=0.5,
+            suspicion_weight=0.5,
+        ),
+    )
+
+    assert components.quality_score == pytest.approx(0.55)
+    assert components.reliability_score == 0.0
+    assert components.suspicion_score < 1.0
+    assert components.final_score < components.quality_score
+
+
+def test_score_aggregation_keeps_penalties_opt_in():
+    telemetry = ValidatorTelemetryState()
+    for _ in range(5):
+        telemetry.record(
+            MinerTelemetryEvent(
+                uid=1,
+                score=0.0,
+                latency=10.0,
+                task_family="hardened-activitynet",
+                failure_kind="timeout",
+            )
+        )
+
+    components = update_miner_score(
+        previous_score=0.5,
+        instant_score=1.0,
+        telemetry_summary=telemetry.summaries[1],
+        config=ScoreAggregationConfig(alpha=0.1),
+    )
+
+    assert components.final_score == components.quality_score

--- a/tests/unit/test_validator_hardened_tasks.py
+++ b/tests/unit/test_validator_hardened_tasks.py
@@ -486,8 +486,9 @@ def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):
     monkeypatch.setattr("chronoseek.validator.forward.query_miner", fake_query_miner)
 
     async def execute():
+        telemetry_events = []
         async with httpx.AsyncClient() as client:
-            return await run_step(
+            scores = await run_step(
                 StaticTaskGenerator(),
                 SimpleNamespace(uids=[0], hotkeys=["hotkey-1"]),
                 wallet=SimpleNamespace(),
@@ -501,15 +502,21 @@ def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):
                 ],
                 validator_eval_top_k=1,
                 max_prediction_duration_seconds=60.0,
+                telemetry_recorder=telemetry_events.append,
             )
+        return scores, telemetry_events
 
-    scores = asyncio.run(execute())
+    scores, telemetry_events = asyncio.run(execute())
 
     assert scores == [(0, 1.0)]
     assert captured["request"].video_url == "https://hippius.example/task.mp4"
     assert captured["request"].query == "private query"
     assert captured["request"].top_k == 1
     assert captured["request"].request_id == "request-1"
+    assert telemetry_events[0].uid == 0
+    assert telemetry_events[0].score == 1.0
+    assert telemetry_events[0].task_family == "hardened-activitynet"
+    assert telemetry_events[0].top_start == 2.0
 
 
 def test_run_step_rewards_successful_empty_absent_canary_response(monkeypatch):

--- a/tests/unit/test_validator_hardened_tasks.py
+++ b/tests/unit/test_validator_hardened_tasks.py
@@ -172,6 +172,31 @@ def test_task_sampler_is_secret_seeded_and_respects_caption_cooldown():
         raise AssertionError("caption cooldown should block immediate replay")
 
 
+def test_task_sampler_collects_same_video_hard_negative_candidates():
+    sampler = ActivityNetTaskSampler(
+        [
+            {
+                "task_id": "video-1",
+                "video_url": "https://example.com/source.mp4",
+                "caption_intervals": {
+                    "person opens a door": [(12, 15)],
+                    "person closes a door": [(18, 20)],
+                },
+            }
+        ],
+        validator_hotkey="hotkey",
+        task_secret="secret",
+        video_cooldown_seconds=0,
+        caption_cooldown_seconds=0,
+    )
+
+    sample, _ = sampler.sample(block=100, nonce=1)
+
+    assert len(sample.hard_negatives) == 1
+    assert sample.hard_negatives[0].caption != sample.caption
+    assert sample.hard_negatives[0].ground_truths in ([(12.0, 15.0)], [(18.0, 20.0)])
+
+
 def test_artifact_manifest_records_active_hashes_and_cleans_expired(tmp_path):
     local_file = tmp_path / "artifact.mp4"
     local_file.write_bytes(b"video")
@@ -207,8 +232,10 @@ class FakeClipper:
     def __init__(self, root: Path):
         self.root = root
         self.encoding_profile = EncodingProfile()
+        self.calls = []
 
     def create_clip(self, **kwargs):
+        self.calls.append(kwargs)
         task_id = kwargs["task_id"]
         path = self.root / f"{task_id}.mp4"
         path.write_bytes(b"clip")
@@ -312,13 +339,23 @@ def test_hardened_cleanup_can_delete_remote_artifacts_when_enabled(tmp_path):
 
 def test_hardened_generator_outputs_clip_local_protocol_task(tmp_path):
     variants_path = tmp_path / "variants.json"
-    variants_path.write_text(json.dumps({"raw caption": ["private query"]}))
+    variants_path.write_text(
+        json.dumps(
+            {
+                "raw caption": ["private query"],
+                "distractor caption": ["private distractor query"],
+            }
+        )
+    )
     sampler = ActivityNetTaskSampler(
         [
             {
                 "task_id": "video-1",
                 "video_url": "https://example.com/source.mp4",
-                "caption_intervals": {"raw caption": [(12, 15)]},
+                "caption_intervals": {
+                    "raw caption": [(12, 15)],
+                    "distractor caption": [(18, 20)],
+                },
             }
         ],
         validator_hotkey="hotkey",
@@ -328,10 +365,11 @@ def test_hardened_generator_outputs_clip_local_protocol_task(tmp_path):
     )
     manifest = TaskArtifactManifest(tmp_path / "manifest.json")
     storage = FakeStorage()
+    clipper = FakeClipper(tmp_path)
     generator = HardenedActivityNetTaskGenerator(
         sampler=sampler,
         query_selector=QueryVariantSelector(str(variants_path)),
-        clipper=FakeClipper(tmp_path),
+        clipper=clipper,
         compressor=FakeCompressor(),
         storage=storage,
         manifest=manifest,
@@ -350,12 +388,17 @@ def test_hardened_generator_outputs_clip_local_protocol_task(tmp_path):
     assert isinstance(task, ValidationTask)
     assert task.video_url.startswith("https://hippius.example/task-clips/")
     assert task.artifact_key == f"task-clips/{task.task_id}.mp4"
-    assert task.query == "private query"
+    assert task.query in {"private query", "private distractor query"}
     assert task.ground_truths == [(2.0, 5.0)]
     assert task.clip_duration == 15.0
     assert task.source_video_id == "video-1"
     assert storage.uploads[0][1] == task.artifact_key
     assert task.task_id in manifest.entries
+    assert clipper.calls[0]["hard_negative_intervals"]
+    assert task.transform_id.startswith("h264-720p-v1:")
+    assert task.transform_metadata["encoding_profile"] == task.transform_id
+    assert task.hard_negative_count == 1
+    assert len(task.hard_negative_source_caption_ids) == 1
 
 
 def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):

--- a/tests/unit/test_validator_hardened_tasks.py
+++ b/tests/unit/test_validator_hardened_tasks.py
@@ -11,7 +11,7 @@ from chronoseek.chutes.runtime import ChutesRuntimeEndpoint
 from chronoseek.protocol_models import VideoSearchResult
 from chronoseek.protocol_models import VideoSearchResponse
 from chronoseek.scoring import score_response
-from chronoseek.validator.forward import MinerQueryResult, run_step
+from chronoseek.validator.forward import MinerQueryFailure, MinerQueryResult, run_step
 from chronoseek.validator.artifact_manifest import (
     ArtifactManifestEntry,
     TaskArtifactManifest,
@@ -401,6 +401,53 @@ def test_hardened_generator_outputs_clip_local_protocol_task(tmp_path):
     assert len(task.hard_negative_source_caption_ids) == 1
 
 
+def test_hardened_generator_can_emit_absent_canary_task(tmp_path):
+    variants_path = tmp_path / "variants.json"
+    variants_path.write_text(json.dumps({"raw caption": ["private query"]}))
+    sampler = ActivityNetTaskSampler(
+        [
+            {
+                "task_id": "video-1",
+                "video_url": "https://example.com/source.mp4",
+                "caption_intervals": {"raw caption": [(12, 15)]},
+            }
+        ],
+        validator_hotkey="hotkey",
+        task_secret="secret",
+        video_cooldown_seconds=0,
+        caption_cooldown_seconds=0,
+    )
+    generator = HardenedActivityNetTaskGenerator(
+        sampler=sampler,
+        query_selector=QueryVariantSelector(str(variants_path)),
+        clipper=FakeClipper(tmp_path),
+        compressor=FakeCompressor(),
+        storage=FakeStorage(),
+        manifest=TaskArtifactManifest(tmp_path / "manifest.json"),
+        validator_hotkey="hotkey",
+        current_block_provider=lambda: 123,
+        config=HardenedTaskGeneratorConfig(
+            artifact_prefix="task-clips",
+            ttl_hours=6,
+            cleanup_interval_seconds=900,
+            max_generation_attempts=1,
+            canary_task_rate=1.0,
+            absent_canary_queries=("absent verifier event",),
+        ),
+    )
+
+    task = generator.generate_task()
+    normalized = normalize_generated_task(task, default_top_k=1)
+
+    assert task.task_family == "canary-absent"
+    assert task.canary_kind == "absent"
+    assert task.expects_empty_response is True
+    assert task.ground_truths == []
+    assert task.query == "absent verifier event"
+    assert normalized.expects_empty_response is True
+    assert normalized.canary_kind == "absent"
+
+
 def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):
     task = ValidationTask(
         task_id="task-1",
@@ -463,3 +510,120 @@ def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):
     assert captured["request"].query == "private query"
     assert captured["request"].top_k == 1
     assert captured["request"].request_id == "request-1"
+
+
+def test_run_step_rewards_successful_empty_absent_canary_response(monkeypatch):
+    task = ValidationTask(
+        task_id="task-1",
+        request_id="request-1",
+        video_url="https://hippius.example/task.mp4",
+        query="absent verifier event",
+        ground_truths=[],
+        clip_duration=15.0,
+        source_video_id="video-1",
+        source_caption_id="caption-1",
+        crop_start=10.0,
+        crop_end=25.0,
+        query_variant_id="canary:absent",
+        artifact_url="https://hippius.example/task.mp4",
+        artifact_key="task-clips/task.mp4",
+        expires_at=time.time() + 3600,
+        task_family="canary-absent",
+        canary_kind="absent",
+        expects_empty_response=True,
+    )
+
+    class StaticTaskGenerator:
+        def generate_task(self):
+            return task
+
+    async def fake_query_miner(*args, **kwargs):
+        request_model = args[4]
+        return MinerQueryResult(
+            response=VideoSearchResponse(
+                request_id=request_model.request_id,
+                results=[],
+            ),
+            latency=0.1,
+        )
+
+    monkeypatch.setattr("chronoseek.validator.forward.query_miner", fake_query_miner)
+
+    async def execute():
+        async with httpx.AsyncClient() as client:
+            return await run_step(
+                StaticTaskGenerator(),
+                SimpleNamespace(uids=[0], hotkeys=["hotkey-1"]),
+                wallet=SimpleNamespace(),
+                client=client,
+                miner_endpoints=[
+                    ChutesRuntimeEndpoint(
+                        uid=0,
+                        hotkey="hotkey-1",
+                        endpoint="https://runtime.example",
+                    )
+                ],
+                validator_eval_top_k=1,
+                max_prediction_duration_seconds=60.0,
+            )
+
+    assert asyncio.run(execute()) == [(0, 1.0)]
+
+
+def test_run_step_does_not_reward_failed_empty_absent_canary_response(monkeypatch):
+    task = ValidationTask(
+        task_id="task-1",
+        request_id="request-1",
+        video_url="https://hippius.example/task.mp4",
+        query="absent verifier event",
+        ground_truths=[],
+        clip_duration=15.0,
+        source_video_id="video-1",
+        source_caption_id="caption-1",
+        crop_start=10.0,
+        crop_end=25.0,
+        query_variant_id="canary:absent",
+        artifact_url="https://hippius.example/task.mp4",
+        artifact_key="task-clips/task.mp4",
+        expires_at=time.time() + 3600,
+        task_family="canary-absent",
+        canary_kind="absent",
+        expects_empty_response=True,
+    )
+
+    class StaticTaskGenerator:
+        def generate_task(self):
+            return task
+
+    async def fake_query_miner(*args, **kwargs):
+        request_model = args[4]
+        return MinerQueryResult(
+            response=VideoSearchResponse(
+                request_id=request_model.request_id,
+                results=[],
+            ),
+            latency=0.0,
+            failure=MinerQueryFailure(kind="timeout", message="timed out"),
+        )
+
+    monkeypatch.setattr("chronoseek.validator.forward.query_miner", fake_query_miner)
+
+    async def execute():
+        async with httpx.AsyncClient() as client:
+            return await run_step(
+                StaticTaskGenerator(),
+                SimpleNamespace(uids=[0], hotkeys=["hotkey-1"]),
+                wallet=SimpleNamespace(),
+                client=client,
+                miner_endpoints=[
+                    ChutesRuntimeEndpoint(
+                        uid=0,
+                        hotkey="hotkey-1",
+                        endpoint="https://runtime.example",
+                    )
+                ],
+                validator_eval_top_k=1,
+                max_prediction_duration_seconds=60.0,
+            )
+
+    assert asyncio.run(execute()) == [(0, 0.0)]

--- a/tests/unit/test_validator_hardened_tasks.py
+++ b/tests/unit/test_validator_hardened_tasks.py
@@ -228,6 +228,34 @@ def test_artifact_manifest_records_active_hashes_and_cleans_expired(tmp_path):
     assert deleted_remote == ["task-clips/expired-task.mp4"]
 
 
+def test_artifact_manifest_exposure_counts_and_summary(tmp_path):
+    manifest = TaskArtifactManifest(tmp_path / "manifest.json")
+    now = time.time()
+    manifest.add(
+        ArtifactManifestEntry(
+            task_id="active-task",
+            object_key="task-clips/active-task.mp4",
+            public_url="https://public.example/active-task.mp4",
+            local_path=str(tmp_path / "active-task.mp4"),
+            source_task_hash="source-hash",
+            encoding_profile="h264-720p-v1",
+            created_at=now,
+            expires_at=now + 3600,
+            source_video_id="video-1",
+            source_caption_id="caption-1",
+            query_variant_id="private:caption-1:0",
+            crop_bucket="10-20",
+            transform_id="h264-720p-v1:base",
+            task_family="canary-absent",
+        )
+    )
+
+    assert manifest.exposure_counts(field_name="source_video_id", now=now) == {
+        "video-1": 1
+    }
+    assert manifest.exposure_summary(now=now)["task_families"] == 1
+
+
 class FakeClipper:
     def __init__(self, root: Path):
         self.root = root
@@ -446,6 +474,63 @@ def test_hardened_generator_can_emit_absent_canary_task(tmp_path):
     assert task.query == "absent verifier event"
     assert normalized.expects_empty_response is True
     assert normalized.canary_kind == "absent"
+    assert generator.manifest.entries[task.task_id].task_family == "canary-absent"
+
+
+def test_hardened_generator_respects_active_source_caption_limit(tmp_path):
+    manifest = TaskArtifactManifest(tmp_path / "manifest.json")
+    now = time.time()
+    manifest.add(
+        ArtifactManifestEntry(
+            task_id="active-task",
+            object_key="task-clips/active-task.mp4",
+            public_url="https://public.example/active-task.mp4",
+            local_path=str(tmp_path / "active-task.mp4"),
+            source_task_hash="source-hash",
+            encoding_profile="h264-720p-v1",
+            created_at=now,
+            expires_at=now + 3600,
+            source_video_id="video-1",
+            source_caption_id="caption-1",
+        )
+    )
+
+    class FixedSampler:
+        def sample(self, **kwargs):
+            from chronoseek.validator.task_sampler import SampledActivityNetMoment
+
+            return (
+                SampledActivityNetMoment(
+                    source_video_id="video-1",
+                    source_url="https://example.com/source.mp4",
+                    source_caption_id="caption-1",
+                    caption="raw caption",
+                    ground_truths=[(12, 15)],
+                ),
+                __import__("random").Random(1),
+            )
+
+    generator = HardenedActivityNetTaskGenerator(
+        sampler=FixedSampler(),
+        query_selector=QueryVariantSelector(None),
+        clipper=FakeClipper(tmp_path),
+        compressor=FakeCompressor(),
+        storage=FakeStorage(),
+        manifest=manifest,
+        validator_hotkey="hotkey",
+        current_block_provider=lambda: 123,
+        config=HardenedTaskGeneratorConfig(
+            max_generation_attempts=1,
+            max_active_tasks_per_source_caption=1,
+        ),
+    )
+
+    try:
+        generator.generate_task()
+    except RuntimeError as exc:
+        assert "Unable to generate hardened validator task" in str(exc)
+    else:
+        raise AssertionError("source caption exposure limit should block generation")
 
 
 def test_run_step_accepts_validation_task_and_sends_top_k_one(monkeypatch):

--- a/tests/unit/test_validator_telemetry.py
+++ b/tests/unit/test_validator_telemetry.py
@@ -1,0 +1,56 @@
+import json
+
+from chronoseek.validator.telemetry import (
+    MinerTelemetryEvent,
+    ValidatorTelemetryState,
+)
+
+
+def test_validator_telemetry_summarizes_scores_errors_and_latency(tmp_path):
+    telemetry = ValidatorTelemetryState(max_events=3)
+    for _ in range(5):
+        telemetry.record(
+            MinerTelemetryEvent(
+                uid=7,
+                score=0.0,
+                latency=30.0,
+                task_family="hardened-activitynet",
+                failure_kind="timeout",
+            )
+        )
+
+    summary = telemetry.summaries[7]
+
+    assert len(telemetry.events) == 3
+    assert summary.attempts == 5
+    assert summary.failures == 5
+    assert summary.timeouts == 5
+    assert summary.error_rate == 1.0
+    assert summary.timeout_rate == 1.0
+    assert "high_error_rate" in summary.suspicion_flags()
+    assert "high_timeout_rate" in summary.suspicion_flags()
+
+    output_path = tmp_path / "telemetry.json"
+    telemetry.save_json(output_path)
+    payload = json.loads(output_path.read_text())
+    assert payload["summaries"]["7"]["attempts"] == 5
+
+
+def test_validator_telemetry_flags_repeated_prediction_durations():
+    telemetry = ValidatorTelemetryState()
+    for _ in range(5):
+        telemetry.record(
+            MinerTelemetryEvent(
+                uid=3,
+                score=0.2,
+                latency=1.0,
+                task_family="hardened-activitynet",
+                top_start=10.0,
+                top_end=20.0,
+            )
+        )
+
+    summary = telemetry.summaries[3]
+
+    assert summary.dominant_duration_rate == 1.0
+    assert "repeated_prediction_duration" in summary.suspicion_flags()

--- a/validator.py
+++ b/validator.py
@@ -21,6 +21,7 @@ load_dotenv()
 
 from chronoseek.validator import task_gen as task_gen_module
 from chronoseek.validator import forward as forward_module
+from chronoseek.scoring import LatencyScoringConfig
 from chronoseek.hippius.s3 import HippiusS3Config, HippiusS3StorageClient
 from chronoseek.validator.artifact_manifest import TaskArtifactManifest
 from chronoseek.validator.aggregation import (
@@ -603,6 +604,20 @@ async def run_validator_loop(
                 max_prediction_duration_seconds=float(
                     config.task_max_prediction_duration_seconds
                 ),
+                latency_scoring_config=LatencyScoringConfig(
+                    enabled=get_config_bool(config, "enable_latency_multiplier", False),
+                    grace_seconds=get_config_float(
+                        config,
+                        "latency_grace_seconds",
+                        30.0,
+                    ),
+                    timeout_seconds=float(config.miner_request_timeout_seconds),
+                    min_multiplier=get_config_float(
+                        config,
+                        "latency_min_multiplier",
+                        0.85,
+                    ),
+                ),
                 telemetry_recorder=runtime.telemetry.record,
             )
 
@@ -998,6 +1013,24 @@ def get_config():
         type=float,
         default=float(os.getenv("TASK_MAX_PREDICTION_DURATION_SECONDS", "60")),
         help="Maximum scored miner interval duration unless the ground-truth interval is longer.",
+    )
+    parser.add_argument(
+        "--enable-latency-multiplier",
+        action="store_true",
+        default=env_bool("ENABLE_LATENCY_MULTIPLIER", False),
+        help="Apply a gentle latency multiplier after interval quality scoring.",
+    )
+    parser.add_argument(
+        "--latency-grace-seconds",
+        type=float,
+        default=float(os.getenv("LATENCY_GRACE_SECONDS", "30")),
+        help="Latency before the optional multiplier begins decaying.",
+    )
+    parser.add_argument(
+        "--latency-min-multiplier",
+        type=float,
+        default=float(os.getenv("LATENCY_MIN_MULTIPLIER", "0.85")),
+        help="Lowest multiplier applied near the miner request timeout.",
     )
     parser.add_argument(
         "--hippius-s3-endpoint-url",

--- a/validator.py
+++ b/validator.py
@@ -447,6 +447,16 @@ def build_validator_task_generator(
                 if query.strip()
             )
             or HardenedTaskGeneratorConfig.absent_canary_queries,
+            max_active_tasks_per_source_video=int(
+                config.max_active_tasks_per_source_video
+            ),
+            max_active_tasks_per_source_caption=int(
+                config.max_active_tasks_per_source_caption
+            ),
+            max_active_tasks_per_query_variant=int(
+                config.max_active_tasks_per_query_variant
+            ),
+            max_active_tasks_per_transform=int(config.max_active_tasks_per_transform),
         ),
     )
     hardened_gen.cleanup_expired(force=True)
@@ -928,6 +938,30 @@ def get_config():
         type=str,
         default=os.getenv("ABSENT_CANARY_QUERIES", ""),
         help="Pipe-separated absent-query canary prompts. Defaults to built-in unlikely prompts.",
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-source-video",
+        type=int,
+        default=int(os.getenv("MAX_ACTIVE_TASKS_PER_SOURCE_VIDEO", "0")),
+        help="Maximum active hardened artifacts per source video. 0 disables the limit.",
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-source-caption",
+        type=int,
+        default=int(os.getenv("MAX_ACTIVE_TASKS_PER_SOURCE_CAPTION", "0")),
+        help="Maximum active hardened artifacts per source caption. 0 disables the limit.",
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-query-variant",
+        type=int,
+        default=int(os.getenv("MAX_ACTIVE_TASKS_PER_QUERY_VARIANT", "0")),
+        help="Maximum active hardened artifacts per query variant. 0 disables the limit.",
+    )
+    parser.add_argument(
+        "--max-active-tasks-per-transform",
+        type=int,
+        default=int(os.getenv("MAX_ACTIVE_TASKS_PER_TRANSFORM", "0")),
+        help="Maximum active hardened artifacts per encoding transform. 0 disables the limit.",
     )
     parser.add_argument(
         "--validator-eval-top-k",

--- a/validator.py
+++ b/validator.py
@@ -589,6 +589,7 @@ async def run_validator_loop(
                 max_prediction_duration_seconds=float(
                     config.task_max_prediction_duration_seconds
                 ),
+                telemetry_recorder=runtime.telemetry.record,
             )
 
             # Update moving average scores
@@ -622,6 +623,24 @@ async def run_validator_loop(
                     for uid, score in ranked_moving_scores[:10]
                 )
                 bt.logging.info(f"Moving scores: {moving_summary}")
+
+                telemetry_path = get_config_str(
+                    config,
+                    "validator_telemetry_path",
+                    "",
+                ).strip()
+                if telemetry_path:
+                    runtime.telemetry.save_json(telemetry_path)
+
+                telemetry_snapshot = runtime.telemetry.snapshot()
+                summary_items = telemetry_snapshot.get("summaries", {})
+                flagged = [
+                    (uid, payload.get("suspicion_flags", []))
+                    for uid, payload in summary_items.items()
+                    if payload.get("suspicion_flags")
+                ]
+                if flagged:
+                    bt.logging.warning(f"Telemetry suspicion flags: {flagged[:10]}")
 
             # --- 2. Set Weights ---
             blocks_since_last = current_block - last_weight_block
@@ -982,6 +1001,12 @@ def get_config():
         type=float,
         default=float(os.getenv("MINER_SUBMISSION_HEALTH_TIMEOUT_SECONDS", "10")),
         help="Per-runtime timeout for /health checks during responsive miner refresh.",
+    )
+    parser.add_argument(
+        "--validator-telemetry-path",
+        type=str,
+        default=os.getenv("VALIDATOR_TELEMETRY_PATH", ""),
+        help="Optional JSON path for validator miner behavior telemetry snapshots.",
     )
     parser.add_argument(
         "--chutes-base-domain",

--- a/validator.py
+++ b/validator.py
@@ -23,6 +23,10 @@ from chronoseek.validator import task_gen as task_gen_module
 from chronoseek.validator import forward as forward_module
 from chronoseek.hippius.s3 import HippiusS3Config, HippiusS3StorageClient
 from chronoseek.validator.artifact_manifest import TaskArtifactManifest
+from chronoseek.validator.aggregation import (
+    ScoreAggregationConfig,
+    update_miner_score,
+)
 from chronoseek.validator.clipper import FfmpegClipper
 from chronoseek.validator.compression import (
     CompositeCompressor,
@@ -592,11 +596,37 @@ async def run_validator_loop(
                 telemetry_recorder=runtime.telemetry.record,
             )
 
-            # Update moving average scores
-            alpha = 0.1
+            # Update aggregate scores. Component weights default to zero, which
+            # preserves the historical quality-only EMA behavior.
+            aggregation_config = ScoreAggregationConfig(
+                alpha=get_config_float(config, "score_ema_alpha", 0.1),
+                reliability_weight=get_config_float(
+                    config,
+                    "score_reliability_weight",
+                    0.0,
+                ),
+                consistency_weight=get_config_float(
+                    config,
+                    "score_consistency_weight",
+                    0.0,
+                ),
+                suspicion_weight=get_config_float(
+                    config,
+                    "score_suspicion_weight",
+                    0.0,
+                ),
+            )
+            aggregate_components = {}
             for uid, score in step_scores:
                 if uid < len(scores):
-                    scores[uid] = alpha * score + (1 - alpha) * scores[uid]
+                    components = update_miner_score(
+                        previous_score=float(scores[uid]),
+                        instant_score=float(score),
+                        telemetry_summary=runtime.telemetry.summaries.get(int(uid)),
+                        config=aggregation_config,
+                    )
+                    scores[uid] = components.final_score
+                    aggregate_components[int(uid)] = components
             with runtime.score_lock:
                 runtime.scores = np.array(scores, copy=True)
 
@@ -623,6 +653,17 @@ async def run_validator_loop(
                     for uid, score in ranked_moving_scores[:10]
                 )
                 bt.logging.info(f"Moving scores: {moving_summary}")
+                if aggregate_components:
+                    component_summary = ", ".join(
+                        (
+                            f"UID {uid}: quality={components.quality_score:.4f} "
+                            f"reliability={components.reliability_score:.2f} "
+                            f"consistency={components.consistency_score:.2f} "
+                            f"suspicion={components.suspicion_score:.2f}"
+                        )
+                        for uid, components in sorted(aggregate_components.items())[:10]
+                    )
+                    bt.logging.info(f"Score components: {component_summary}")
 
                 telemetry_path = get_config_str(
                     config,
@@ -893,6 +934,30 @@ def get_config():
         type=int,
         default=int(os.getenv("VALIDATOR_EVAL_TOP_K", "1")),
         help="Number of miner results requested and scored for synthetic evaluation.",
+    )
+    parser.add_argument(
+        "--score-ema-alpha",
+        type=float,
+        default=float(os.getenv("SCORE_EMA_ALPHA", "0.1")),
+        help="EMA alpha used for instant miner quality scores.",
+    )
+    parser.add_argument(
+        "--score-reliability-weight",
+        type=float,
+        default=float(os.getenv("SCORE_RELIABILITY_WEIGHT", "0")),
+        help="Optional reliability multiplier weight applied after quality scoring.",
+    )
+    parser.add_argument(
+        "--score-consistency-weight",
+        type=float,
+        default=float(os.getenv("SCORE_CONSISTENCY_WEIGHT", "0")),
+        help="Optional consistency multiplier weight applied after quality scoring.",
+    )
+    parser.add_argument(
+        "--score-suspicion-weight",
+        type=float,
+        default=float(os.getenv("SCORE_SUSPICION_WEIGHT", "0")),
+        help="Optional suspicion multiplier weight applied after quality scoring.",
     )
     parser.add_argument(
         "--task-max-prediction-duration-seconds",

--- a/validator.py
+++ b/validator.py
@@ -436,6 +436,13 @@ def build_validator_task_generator(
                 "enable_task_encoding_profile_variants",
                 True,
             ),
+            canary_task_rate=float(config.canary_task_rate),
+            absent_canary_queries=tuple(
+                query.strip()
+                for query in str(config.absent_canary_queries or "").split("|")
+                if query.strip()
+            )
+            or HardenedTaskGeneratorConfig.absent_canary_queries,
         ),
     )
     hardened_gen.cleanup_expired(force=True)
@@ -849,6 +856,18 @@ def get_config():
         action="store_false",
         dest="enable_task_encoding_profile_variants",
         help="Disable randomized encoding profile variants for hardened task clips.",
+    )
+    parser.add_argument(
+        "--canary-task-rate",
+        type=float,
+        default=float(os.getenv("CANARY_TASK_RATE", "0")),
+        help="Fraction of hardened tasks converted into internal validator canaries.",
+    )
+    parser.add_argument(
+        "--absent-canary-queries",
+        type=str,
+        default=os.getenv("ABSENT_CANARY_QUERIES", ""),
+        help="Pipe-separated absent-query canary prompts. Defaults to built-in unlikely prompts.",
     )
     parser.add_argument(
         "--validator-eval-top-k",

--- a/validator.py
+++ b/validator.py
@@ -426,6 +426,16 @@ def build_validator_task_generator(
                 "task_delete_remote_artifacts",
                 False,
             ),
+            enable_adversarial_transforms=get_config_bool(
+                config,
+                "enable_adversarial_task_transforms",
+                True,
+            ),
+            enable_encoding_profile_variants=get_config_bool(
+                config,
+                "enable_task_encoding_profile_variants",
+                True,
+            ),
         ),
     )
     hardened_gen.cleanup_expired(force=True)
@@ -815,6 +825,30 @@ def get_config():
         type=str,
         default=os.getenv("TASK_CLIP_AUDIO_BITRATE", "96k"),
         help="Generated task clip audio bitrate.",
+    )
+    parser.add_argument(
+        "--enable-adversarial-task-transforms",
+        action="store_true",
+        default=env_bool("ENABLE_ADVERSARIAL_TASK_TRANSFORMS", True),
+        help="Enable randomized hardened task transforms such as context and encoding variation.",
+    )
+    parser.add_argument(
+        "--disable-adversarial-task-transforms",
+        action="store_false",
+        dest="enable_adversarial_task_transforms",
+        help="Disable randomized hardened task transforms.",
+    )
+    parser.add_argument(
+        "--enable-task-encoding-profile-variants",
+        action="store_true",
+        default=env_bool("ENABLE_TASK_ENCODING_PROFILE_VARIANTS", True),
+        help="Enable randomized encoding profile variants for hardened task clips.",
+    )
+    parser.add_argument(
+        "--disable-task-encoding-profile-variants",
+        action="store_false",
+        dest="enable_task_encoding_profile_variants",
+        help="Disable randomized encoding profile variants for hardened task clips.",
     )
     parser.add_argument(
         "--validator-eval-top-k",


### PR DESCRIPTION
## Summary
- harden interval scoring with boundary, center, duration, and optional latency dampening
- add adversarial hardened task transforms, hard-negative metadata, canary task support, and task exposure controls
- add report-only miner telemetry plus configurable aggregation components for reliability, consistency, and suspicion signals

## Issue Mapping
- Refs #20
- Refs #21
- Refs #22
- Refs #23
- Refs #24
- Refs #25
- Refs #26

## Tests
- `poetry run python -m pytest tests/unit -q` -> `132 passed`

Note: Torch emits shutdown-time logging errors after pytest completion in this environment, but pytest exits successfully.
