### PR TITLE
Permanent exclusion for cloned chute_slug submissions

### DIFF
--- a/chronoseek/chain/submissions.py
+++ b/chronoseek/chain/submissions.py
@@ -321,10 +321,57 @@ async def load_chain_submission_snapshot(
         if submission:
             submissions[hotkey] = submission
 
+    submissions, cloned_hotkeys = _disqualify_cloned_chute_slug_submissions(
+        submissions
+    )
+    duplicate_hotkeys |= cloned_hotkeys
+
     return ChainSubmissionSnapshot(
         submissions=submissions,
         duplicate_hotkeys=duplicate_hotkeys,
     )
+
+
+def _disqualify_cloned_chute_slug_submissions(
+    submissions: dict[str, MinerSubmission],
+) -> tuple[dict[str, MinerSubmission], set[str]]:
+    """
+    Among hotkeys sharing the same chute_slug, only the one whose commitment
+    was revealed first (lowest created_at_block, not registration time) keeps
+    it - every other hotkey sharing that slug is permanently disqualified,
+    same treatment as the one-submission-per-hotkey rule above.
+    """
+    by_slug: dict[str, list[str]] = {}
+    for hotkey, submission in submissions.items():
+        slug = submission.chute_slug
+        if not slug:
+            continue
+        by_slug.setdefault(slug, []).append(hotkey)
+
+    def reveal_order(hotkey: str) -> tuple[int, str]:
+        block = submissions[hotkey].created_at_block
+        return (block if block is not None else 0, hotkey)
+
+    cloned_hotkeys: set[str] = set()
+    for slug, hotkeys_sharing_slug in by_slug.items():
+        if len(hotkeys_sharing_slug) < 2:
+            continue
+
+        ranked = sorted(hotkeys_sharing_slug, key=reveal_order)
+        first_revealed, losers = ranked[0], ranked[1:]
+        cloned_hotkeys.update(losers)
+        logger.warning(
+            f"Disqualifying hotkeys {losers} for sharing chute_slug {slug!r} "
+            f"already claimed by {first_revealed} (revealed first); cloned "
+            "submissions are permanently disqualified."
+        )
+
+    filtered_submissions = {
+        hotkey: submission
+        for hotkey, submission in submissions.items()
+        if hotkey not in cloned_hotkeys
+    }
+    return filtered_submissions, cloned_hotkeys
 
 
 class MinerSubmissionResolver:

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -154,6 +154,8 @@ poetry run python miner.py \
 
 Miner runtime submissions are permanent per hotkey. A hotkey can submit only once; to submit a different runtime later, register and use a new miner hotkey. Validators disqualify hotkeys with multiple revealed submissions and assign them zero score.
 
+Copying another hotkey's `chute_slug` into your own submission does not work either: when two or more hotkeys share the same `chute_slug`, only the one whose commitment was revealed first (by reveal block, not registration time) is scored - every other hotkey sharing that slug is permanently disqualified, the same as the duplicate-submission rule above.
+
 For tests that require replacing a submitted runtime, set `ENFORCE_ONE_HOTKEY_ONE_SUBMISSION=0` for both the miner and validator. The miner then skips its duplicate check, and the validator uses the newest revealed submission without applying the duplicate-submission penalty. Production behavior remains enabled by default.
 
 Before submitting, you can check whether the selected hotkey already has revealed commit data:

--- a/tests/unit/test_validator_submissions.py
+++ b/tests/unit/test_validator_submissions.py
@@ -238,6 +238,159 @@ class TestAsyncSubmissionRouting(unittest.IsolatedAsyncioTestCase):
         assert "hk-1" not in snapshot.submissions
         assert snapshot.duplicate_hotkeys == {"hk-1"}
 
+    async def test_load_chain_submissions_disqualifies_later_revealed_cloned_slug(
+        self,
+    ):
+        class FakeSubtensor:
+            def __init__(self):
+                self.subnets = SimpleNamespace(commitments=self.commitments)
+
+            def commitments(self, netuid):
+                assert netuid == 1
+                return {
+                    "hk-0": revealed_commitment(
+                        (
+                            10,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                    "hk-1": revealed_commitment(
+                        (
+                            20,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                }
+
+        snapshot = await load_chain_submission_snapshot(
+            FakeSubtensor(),
+            netuid=1,
+            metagraph=DummyMetagraph(),
+        )
+
+        assert "hk-0" in snapshot.submissions
+        assert "hk-1" not in snapshot.submissions
+        assert snapshot.duplicate_hotkeys == {"hk-1"}
+
+    async def test_load_chain_submissions_disqualifies_all_but_first_in_three_way_clone(
+        self,
+    ):
+        class ThreeHotkeyMetagraph:
+            def __init__(self):
+                self.uids = [0, 1, 2]
+                self.hotkeys = ["hk-0", "hk-1", "hk-2"]
+
+        class FakeSubtensor:
+            def __init__(self):
+                self.subnets = SimpleNamespace(commitments=self.commitments)
+
+            def commitments(self, netuid):
+                assert netuid == 1
+                return {
+                    "hk-0": revealed_commitment(
+                        (
+                            30,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                    "hk-1": revealed_commitment(
+                        (
+                            10,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                    "hk-2": revealed_commitment(
+                        (
+                            20,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                }
+
+        snapshot = await load_chain_submission_snapshot(
+            FakeSubtensor(),
+            netuid=1,
+            metagraph=ThreeHotkeyMetagraph(),
+        )
+
+        # hk-1 revealed first (block 10) - it keeps the slug. hk-2 (block 20)
+        # and hk-0 (block 30) both lose it, regardless of registration order.
+        assert set(snapshot.submissions) == {"hk-1"}
+        assert snapshot.duplicate_hotkeys == {"hk-0", "hk-2"}
+
+    async def test_load_chain_submissions_keeps_hotkey_with_unique_slug(self):
+        class FakeSubtensor:
+            def __init__(self):
+                self.subnets = SimpleNamespace(commitments=self.commitments)
+
+            def commitments(self, netuid):
+                assert netuid == 1
+                return {
+                    "hk-0": revealed_commitment(
+                        (
+                            10,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "shared-slug",
+                                }
+                            ),
+                        )
+                    ),
+                    "hk-1": revealed_commitment(
+                        (
+                            20,
+                            json.dumps(
+                                {
+                                    "runtime": "chutes",
+                                    "protocol": "chronoseek-runtime-v2",
+                                    "chute_slug": "unique-slug",
+                                }
+                            ),
+                        )
+                    ),
+                }
+
+        snapshot = await load_chain_submission_snapshot(
+            FakeSubtensor(),
+            netuid=1,
+            metagraph=DummyMetagraph(),
+        )
+
+        assert set(snapshot.submissions) == {"hk-0", "hk-1"}
+        assert snapshot.duplicate_hotkeys == set()
+
     async def test_load_chain_submissions_keeps_single_valid_commit(self):
         class FakeSubtensor:
             def __init__(self):


### PR DESCRIPTION
Closes #39.

When two or more hotkeys share the same chute_slug, only the one revealed first on-chain (by reveal block) keeps it - every other hotkey sharing that slug is permanently disqualified, same as the one-submission-per-hotkey rule from #17. Reuses that same duplicate_hotkeys channel, so no other validator code needed to change.